### PR TITLE
feat: StarCraft II Protoss wow animation overhaul

### DIFF
--- a/components/game-theme-toggle.js
+++ b/components/game-theme-toggle.js
@@ -1,40 +1,80 @@
-import { AnimatePresence, motion } from 'framer-motion'
+import { useState } from 'react'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { Button } from '@chakra-ui/react'
 import { useSiteTheme } from '../lib/site-theme-context'
 
+// Full-screen psionic flash played during a theme switch — warp-in to SC2
+// (cyan), warp-out back to FFIX (gold). Skipped under reduced motion.
+const WarpFlash = ({ toSc2, onDone }) => (
+  <motion.div
+    aria-hidden
+    initial={{ opacity: 0 }}
+    animate={{ opacity: [0, 0.85, 0] }}
+    transition={{ duration: 0.7, times: [0, 0.35, 1], ease: 'easeOut' }}
+    onAnimationComplete={onDone}
+    style={{
+      position: 'fixed',
+      inset: 0,
+      zIndex: 2000,
+      pointerEvents: 'none',
+      background: toSc2
+        ? 'radial-gradient(circle at 50% 40%, rgba(0,221,255,0.85), rgba(0,60,90,0.55) 55%, transparent 80%)'
+        : 'radial-gradient(circle at 50% 40%, rgba(224,192,0,0.8), rgba(60,40,0,0.5) 55%, transparent 80%)'
+    }}
+  />
+)
+
 const GameThemeToggle = () => {
   const { theme, toggleTheme } = useSiteTheme()
+  const reduceMotion = useReducedMotion()
+  const [warping, setWarping] = useState(false)
+
+  const handleToggle = () => {
+    if (warping) return // ignore clicks while the flash is playing
+    toggleTheme()
+    if (!reduceMotion) setWarping(true)
+  }
 
   return (
-    <AnimatePresence mode="wait" initial={false}>
-      <motion.div
-        style={{ display: 'inline-block', marginRight: '8px' }}
-        key={theme}
-        initial={{ y: -20, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        exit={{ y: 20, opacity: 0 }}
-        transition={{ duration: 0.2 }}
-      >
-        <Button
-          aria-label="Toggle game theme"
-          size="sm"
-          fontFamily="monospace"
-          fontSize="xs"
-          fontWeight="bold"
-          letterSpacing="0.08em"
-          bg={theme === 'ffix' ? '#c8a800' : '#00bbdd'}
-          color={theme === 'ffix' ? '#1a1000' : '#001a22'}
-          _hover={{
-            bg: theme === 'ffix' ? '#e0c000' : '#00ddff',
-            transform: 'translateY(-1px)',
-          }}
-          transition="all 0.15s"
-          onClick={toggleTheme}
+    <>
+      {/* theme here is already the NEW theme when the flash renders */}
+      {warping && (
+        <WarpFlash toSc2={theme === 'sc2'} onDone={() => setWarping(false)} />
+      )}
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.div
+          style={{ display: 'inline-block', marginRight: '8px' }}
+          key={theme}
+          initial={{ y: -20, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 20, opacity: 0 }}
+          transition={{ duration: 0.2 }}
         >
-          {theme === 'ffix' ? 'FFIX' : 'SC2'}
-        </Button>
-      </motion.div>
-    </AnimatePresence>
+          <Button
+            aria-label="Toggle game theme"
+            size="sm"
+            fontFamily="monospace"
+            fontSize="xs"
+            fontWeight="bold"
+            letterSpacing="0.08em"
+            bg={theme === 'ffix' ? '#c8a800' : '#00bbdd'}
+            color={theme === 'ffix' ? '#1a1000' : '#001a22'}
+            _hover={{
+              bg: theme === 'ffix' ? '#e0c000' : '#00ddff',
+              transform: 'translateY(-1px)',
+              boxShadow:
+                theme === 'ffix'
+                  ? '0 0 12px rgba(224,192,0,0.5)'
+                  : '0 0 12px rgba(0,221,255,0.55)'
+            }}
+            transition="all 0.15s"
+            onClick={handleToggle}
+          >
+            {theme === 'ffix' ? 'FFIX' : 'SC2'}
+          </Button>
+        </motion.div>
+      </AnimatePresence>
+    </>
   )
 }
 

--- a/components/game-theme-toggle.js
+++ b/components/game-theme-toggle.js
@@ -1,7 +1,12 @@
 import { useState } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { Button } from '@chakra-ui/react'
-import { useSiteTheme } from '../lib/site-theme-context'
+import {
+  useSiteTheme,
+  PROTOSS_CYAN,
+  PROTOSS_CYAN_RGB,
+  FFIX_GOLD_RGB
+} from '../lib/site-theme-context'
 
 // Full-screen psionic flash played during a theme switch — warp-in to SC2
 // (cyan), warp-out back to FFIX (gold). Skipped under reduced motion.
@@ -18,8 +23,8 @@ const WarpFlash = ({ toSc2, onDone }) => (
       zIndex: 2000,
       pointerEvents: 'none',
       background: toSc2
-        ? 'radial-gradient(circle at 50% 40%, rgba(0,221,255,0.85), rgba(0,60,90,0.55) 55%, transparent 80%)'
-        : 'radial-gradient(circle at 50% 40%, rgba(224,192,0,0.8), rgba(60,40,0,0.5) 55%, transparent 80%)'
+        ? `radial-gradient(circle at 50% 40%, rgba(${PROTOSS_CYAN_RGB}, 0.85), rgba(0,60,90,0.55) 55%, transparent 80%)`
+        : `radial-gradient(circle at 50% 40%, rgba(${FFIX_GOLD_RGB}, 0.8), rgba(60,40,0,0.5) 55%, transparent 80%)`
     }}
   />
 )
@@ -60,12 +65,12 @@ const GameThemeToggle = () => {
             bg={theme === 'ffix' ? '#c8a800' : '#00bbdd'}
             color={theme === 'ffix' ? '#1a1000' : '#001a22'}
             _hover={{
-              bg: theme === 'ffix' ? '#e0c000' : '#00ddff',
+              bg: theme === 'ffix' ? '#e0c000' : PROTOSS_CYAN,
               transform: 'translateY(-1px)',
               boxShadow:
                 theme === 'ffix'
-                  ? '0 0 12px rgba(224,192,0,0.5)'
-                  : '0 0 12px rgba(0,221,255,0.55)'
+                  ? `0 0 12px rgba(${FFIX_GOLD_RGB}, 0.5)`
+                  : `0 0 12px rgba(${PROTOSS_CYAN_RGB}, 0.55)`
             }}
             transition="all 0.15s"
             onClick={handleToggle}

--- a/components/layouts/main.js
+++ b/components/layouts/main.js
@@ -16,16 +16,27 @@ const LazyProtossPylon = dynamic(() => import('../protoss-pylon'), {
   loading: () => <VoxelDogLoader />
 })
 
+// SC2-only animated psionic background layer (client-side canvas)
+const LazyPsionicBackground = dynamic(() => import('../psionic-background'), {
+  ssr: false
+})
+
 const Main = ({ children, router }) => {
   const { theme } = useSiteTheme()
   return (
     <Box as="main" pb={8}>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content="Building products that scale. Head of Tech Partnership at Ecomdy Media, TikTok Marketing Partner. 19+ years in JavaScript & e-commerce. Danang, Vietnam." />
+        <meta
+          name="description"
+          content="Building products that scale. Head of Tech Partnership at Ecomdy Media, TikTok Marketing Partner. 19+ years in JavaScript & e-commerce. Danang, Vietnam."
+        />
         <meta name="author" content="Tony Tin Nguyen" />
         <meta name="robots" content="index, follow" />
-        <link rel="canonical" href={`https://www.nguyenquangtin.com${router.asPath.split('?')[0]}`} />
+        <link
+          rel="canonical"
+          href={`https://www.nguyenquangtin.com${router.asPath.split('?')[0]}`}
+        />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
@@ -34,40 +45,75 @@ const Main = ({ children, router }) => {
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@nguyenquangtin" />
         <meta name="twitter:creator" content="@nguyenquangtin" />
-        <meta name="twitter:title" content="Tony Tin Nguyen — Building products that scale." />
-        <meta name="twitter:description" content="Building products that scale. Head of Tech Partnership at Ecomdy Media, TikTok Marketing Partner. 19+ years in JS & e-commerce." />
-        <meta name="twitter:image" content="https://www.nguyenquangtin.com/card.png" />
+        <meta
+          name="twitter:title"
+          content="Tony Tin Nguyen — Building products that scale."
+        />
+        <meta
+          name="twitter:description"
+          content="Building products that scale. Head of Tech Partnership at Ecomdy Media, TikTok Marketing Partner. 19+ years in JS & e-commerce."
+        />
+        <meta
+          name="twitter:image"
+          content="https://www.nguyenquangtin.com/card.png"
+        />
 
         {/* Open Graph */}
         <meta property="og:site_name" content="Tony Tin Nguyen" />
-        <meta property="og:title" content="Tony Tin Nguyen — Building products that scale." />
-        <meta property="og:description" content="Building products that scale. Head of Tech Partnership at Ecomdy Media, TikTok Marketing Partner. 19+ years in JS & e-commerce." />
+        <meta
+          property="og:title"
+          content="Tony Tin Nguyen — Building products that scale."
+        />
+        <meta
+          property="og:description"
+          content="Building products that scale. Head of Tech Partnership at Ecomdy Media, TikTok Marketing Partner. 19+ years in JS & e-commerce."
+        />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content={`https://www.nguyenquangtin.com${router.asPath.split('?')[0]}`} />
-        <meta property="og:image" content="https://www.nguyenquangtin.com/card.png" />
+        <meta
+          property="og:url"
+          content={`https://www.nguyenquangtin.com${
+            router.asPath.split('?')[0]
+          }`}
+        />
+        <meta
+          property="og:image"
+          content="https://www.nguyenquangtin.com/card.png"
+        />
         <meta property="og:locale" content="en_US" />
 
         {/* JSON-LD Person schema */}
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify({
-            "@context": "https://schema.org",
-            "@type": "Person",
-            "name": "Tony Tin Nguyen",
-            "url": "https://www.nguyenquangtin.com",
-            "jobTitle": "Head of Tech Partnership",
-            "worksFor": { "@type": "Organization", "name": "Ecomdy Media", "url": "https://ecomdymedia.com" },
-            "address": { "@type": "PostalAddress", "addressLocality": "Danang", "addressCountry": "VN" },
-            "sameAs": [
-              "https://github.com/nguyenquangtin",
-              "https://twitter.com/nguyenquangtin",
-              "https://coderhorizon.com"
-            ]
-          })}}
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Person',
+              name: 'Tony Tin Nguyen',
+              url: 'https://www.nguyenquangtin.com',
+              jobTitle: 'Head of Tech Partnership',
+              worksFor: {
+                '@type': 'Organization',
+                name: 'Ecomdy Media',
+                url: 'https://ecomdymedia.com'
+              },
+              address: {
+                '@type': 'PostalAddress',
+                addressLocality: 'Danang',
+                addressCountry: 'VN'
+              },
+              sameAs: [
+                'https://github.com/nguyenquangtin',
+                'https://twitter.com/nguyenquangtin',
+                'https://coderhorizon.com'
+              ]
+            })
+          }}
         />
 
         <title>Tony Tin Nguyen — Building products that scale.</title>
       </Head>
+
+      {theme === 'sc2' && <LazyPsionicBackground />}
 
       <NavBar path={router.asPath} />
 

--- a/components/protoss-pylon.js
+++ b/components/protoss-pylon.js
@@ -21,7 +21,7 @@ function createPylonCrystal(scene) {
     transmission: 0.25,
     thickness: 1.5,
     emissive: 0x0044aa,
-    emissiveIntensity: 0.3,
+    emissiveIntensity: 0.3
   })
   const crystal = new THREE.Mesh(crystalGeo, crystalMat)
   crystal.position.y = 1.5
@@ -32,7 +32,7 @@ function createPylonCrystal(scene) {
   const coreMat = new THREE.MeshBasicMaterial({
     color: 0x00ddff,
     transparent: true,
-    opacity: 0.8,
+    opacity: 0.8
   })
   const core = new THREE.Mesh(coreGeo, coreMat)
   core.position.y = 1.5
@@ -45,7 +45,7 @@ function createPylonCrystal(scene) {
     color: 0x00bbdd,
     transparent: true,
     opacity: 0.06,
-    wireframe: true,
+    wireframe: true
   })
   const field = new THREE.Mesh(fieldGeo, fieldMat)
   field.position.y = 1.5
@@ -56,7 +56,7 @@ function createPylonCrystal(scene) {
   const ringMat = new THREE.MeshBasicMaterial({
     color: 0x00ddff,
     transparent: true,
-    opacity: 0.5,
+    opacity: 0.5
   })
   const ring = new THREE.Mesh(ringGeo, ringMat)
   ring.rotation.x = Math.PI / 2
@@ -69,8 +69,21 @@ function createPylonCrystal(scene) {
   ring2.scale.set(0.7, 0.7, 0.7)
   group.add(ring2)
 
+  // Expanding power-field shockwave — Pylon power radius pulse,
+  // scaled outward and faded in the render loop
+  const pulseGeo = new THREE.TorusGeometry(1.6, 0.05, 8, 48)
+  const pulseMat = new THREE.MeshBasicMaterial({
+    color: 0x00ddff,
+    transparent: true,
+    opacity: 0.4
+  })
+  const pulse = new THREE.Mesh(pulseGeo, pulseMat)
+  pulse.rotation.x = Math.PI / 2
+  pulse.position.y = -1.2
+  group.add(pulse)
+
   scene.add(group)
-  return { crystal, core, field, ring, ring2, group }
+  return { crystal, core, field, ring, ring2, pulse, group }
 }
 
 // Psionic energy particles — cyan sparkles rising upward
@@ -82,10 +95,10 @@ function createPsionicParticles(scene) {
   for (let i = 0; i < count; i++) {
     const theta = Math.random() * Math.PI * 2
     const r = 0.5 + Math.random() * 2.0
-    positions[i * 3]     = r * Math.cos(theta)
+    positions[i * 3] = r * Math.cos(theta)
     positions[i * 3 + 1] = -2 + Math.random() * 5
     positions[i * 3 + 2] = r * Math.sin(theta)
-    velocities[i * 3]     = (Math.random() - 0.5) * 0.002
+    velocities[i * 3] = (Math.random() - 0.5) * 0.002
     velocities[i * 3 + 1] = 0.005 + Math.random() * 0.008
     velocities[i * 3 + 2] = (Math.random() - 0.5) * 0.002
   }
@@ -99,7 +112,7 @@ function createPsionicParticles(scene) {
     transparent: true,
     opacity: 0.7,
     sizeAttenuation: true,
-    depthWrite: false,
+    depthWrite: false
   })
 
   const points = new THREE.Points(geometry, material)
@@ -109,13 +122,13 @@ function createPsionicParticles(scene) {
 
 function updateParticles({ points, velocities, positions, count }) {
   for (let i = 0; i < count; i++) {
-    positions[i * 3]     += velocities[i * 3]
+    positions[i * 3] += velocities[i * 3]
     positions[i * 3 + 1] += velocities[i * 3 + 1]
     positions[i * 3 + 2] += velocities[i * 3 + 2]
     if (positions[i * 3 + 1] > 5) {
       const theta = Math.random() * Math.PI * 2
       const r = 0.3 + Math.random() * 1.5
-      positions[i * 3]     = r * Math.cos(theta)
+      positions[i * 3] = r * Math.cos(theta)
       positions[i * 3 + 1] = -2 + Math.random() * -0.5
       positions[i * 3 + 2] = r * Math.sin(theta)
     }
@@ -159,7 +172,12 @@ const ProtossPylon = () => {
 
       const scale = scH * 0.004 + 3.5
       const camera = new THREE.OrthographicCamera(
-        -scale, scale, scale, -scale, 0.01, 50000
+        -scale,
+        scale,
+        scale,
+        -scale,
+        0.01,
+        50000
       )
       camera.position.copy(initialCameraPosition)
       camera.lookAt(target)
@@ -206,8 +224,10 @@ const ProtossPylon = () => {
           const p = initialCameraPosition
           const rotSpeed = -easeOutCirc(frame / 120) * Math.PI * 20
           camera.position.y = 10
-          camera.position.x = p.x * Math.cos(rotSpeed) + p.z * Math.sin(rotSpeed)
-          camera.position.z = p.z * Math.cos(rotSpeed) - p.x * Math.sin(rotSpeed)
+          camera.position.x =
+            p.x * Math.cos(rotSpeed) + p.z * Math.sin(rotSpeed)
+          camera.position.z =
+            p.z * Math.cos(rotSpeed) - p.x * Math.sin(rotSpeed)
           camera.lookAt(target)
         } else {
           controls.update()
@@ -234,6 +254,15 @@ const ProtossPylon = () => {
         pylon.ring.material.opacity = 0.3 + Math.sin(t * 2.5) * 0.2
         pylon.ring2.material.opacity = 0.3 + Math.sin(t * 2.5 + 1) * 0.2
 
+        // Expanding power-field shockwave — 2.4s loop from base outward
+        const pw = (t % 2.4) / 2.4
+        pylon.pulse.scale.setScalar(1 + pw * 1.8)
+        pylon.pulse.material.opacity = 0.4 * (1 - pw)
+
+        // Crystal emissive throb — psionic charge breathing
+        pylon.crystal.material.emissiveIntensity =
+          0.3 + (Math.sin(t * 1.8) + 1) * 0.2
+
         updateParticles(particles)
         renderer.render(scene, camera)
       }
@@ -242,6 +271,12 @@ const ProtossPylon = () => {
 
       return () => {
         cancelAnimationFrame(req)
+        // renderer.dispose() does not cascade to scene objects —
+        // free GPU buffers explicitly to avoid leaks on theme toggle
+        scene.traverse(obj => {
+          if (obj.geometry) obj.geometry.dispose()
+          if (obj.material && obj.material.dispose) obj.material.dispose()
+        })
         renderer.domElement.remove()
         renderer.dispose()
       }

--- a/components/protoss-warp-in.js
+++ b/components/protoss-warp-in.js
@@ -1,5 +1,5 @@
 import { motion, useReducedMotion } from 'framer-motion'
-import { useSiteTheme } from '../lib/site-theme-context'
+import { useSiteTheme, PROTOSS_CYAN_RGB } from '../lib/site-theme-context'
 
 // Protoss warp-in reveal — unit-summon effect: overbright blur shimmer
 // settling into place, with a psionic glow that fades out.
@@ -36,9 +36,8 @@ const ProtossWarpIn = ({ children, delay = 0 }) => {
           inset: -8,
           borderRadius: 12,
           pointerEvents: 'none',
-          background:
-            'radial-gradient(ellipse at center, rgba(0,221,255,0.20), transparent 70%)',
-          boxShadow: '0 0 42px rgba(0,221,255,0.35)'
+          background: `radial-gradient(ellipse at center, rgba(${PROTOSS_CYAN_RGB}, 0.2), transparent 70%)`,
+          boxShadow: `0 0 42px rgba(${PROTOSS_CYAN_RGB}, 0.35)`
         }}
       />
       {children}

--- a/components/protoss-warp-in.js
+++ b/components/protoss-warp-in.js
@@ -1,0 +1,49 @@
+import { motion, useReducedMotion } from 'framer-motion'
+import { useSiteTheme } from '../lib/site-theme-context'
+
+// Protoss warp-in reveal — unit-summon effect: overbright blur shimmer
+// settling into place, with a psionic glow that fades out.
+// Renders plain children when FFIX theme is active or reduced motion is set.
+const ProtossWarpIn = ({ children, delay = 0 }) => {
+  const { theme } = useSiteTheme()
+  const reduceMotion = useReducedMotion()
+
+  if (theme !== 'sc2' || reduceMotion) return <>{children}</>
+
+  return (
+    <motion.div
+      initial={{
+        opacity: 0,
+        scale: 1.04,
+        filter: 'blur(10px) brightness(2.4) saturate(1.6)'
+      }}
+      animate={{
+        opacity: 1,
+        scale: 1,
+        filter: 'blur(0px) brightness(1) saturate(1)'
+      }}
+      transition={{ duration: 0.9, delay, ease: [0.16, 1, 0.3, 1] }}
+      style={{ position: 'relative' }}
+    >
+      {/* Psionic energy glow — flares on arrival, then dissipates */}
+      <motion.div
+        aria-hidden
+        initial={{ opacity: 0.9 }}
+        animate={{ opacity: 0 }}
+        transition={{ duration: 1.4, delay: delay + 0.15, ease: 'easeOut' }}
+        style={{
+          position: 'absolute',
+          inset: -8,
+          borderRadius: 12,
+          pointerEvents: 'none',
+          background:
+            'radial-gradient(ellipse at center, rgba(0,221,255,0.20), transparent 70%)',
+          boxShadow: '0 0 42px rgba(0,221,255,0.35)'
+        }}
+      />
+      {children}
+    </motion.div>
+  )
+}
+
+export default ProtossWarpIn

--- a/components/psionic-background.js
+++ b/components/psionic-background.js
@@ -1,0 +1,155 @@
+import { useEffect, useRef } from 'react'
+
+// SC2-only animated background: rising psionic motes + breathing pylon
+// power glow at the bottom of the viewport. Fixed full-screen canvas
+// behind all content.
+// Perf: DPR capped at 2, mote count scales with viewport, pauses when
+// the tab is hidden. Accessibility: prefers-reduced-motion renders a
+// single static frame (no animation loop).
+
+const CYAN = '0, 221, 255'
+const TEAL = '0, 187, 221'
+const GOLD = '240, 192, 64' // khala gold accent
+
+function createMotes(w, h) {
+  const count = Math.min(80, Math.max(24, Math.floor((w * h) / 26000)))
+  return Array.from({ length: count }, () => ({
+    x: Math.random() * w,
+    y: Math.random() * h,
+    r: 0.8 + Math.random() * 1.8,
+    speed: 0.15 + Math.random() * 0.45, // upward drift, px per frame
+    sway: 0.3 + Math.random() * 0.7, // horizontal sway factor
+    phase: Math.random() * Math.PI * 2,
+    color: Math.random() < 0.15 ? GOLD : Math.random() < 0.5 ? CYAN : TEAL,
+    alpha: 0.2 + Math.random() * 0.4
+  }))
+}
+
+const PsionicBackground = () => {
+  const canvasRef = useRef()
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const ctx = canvas.getContext('2d')
+    const reduceMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    ).matches
+    let motes = []
+    let req = null
+    let running = false
+    let t = 0
+    let resizeTimer = null
+
+    const resize = () => {
+      const dpr = Math.min(window.devicePixelRatio || 1, 2)
+      canvas.width = window.innerWidth * dpr
+      canvas.height = window.innerHeight * dpr
+      canvas.style.width = `${window.innerWidth}px`
+      canvas.style.height = `${window.innerHeight}px`
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+      motes = createMotes(window.innerWidth, window.innerHeight)
+    }
+
+    const draw = () => {
+      const w = window.innerWidth
+      const h = window.innerHeight
+      ctx.clearRect(0, 0, w, h)
+
+      // Pylon power glow — breathing radial pool rising from below
+      const pulse = reduceMotion ? 0.5 : 0.5 + Math.sin(t * 0.02) * 0.5
+      const glow = ctx.createRadialGradient(
+        w / 2,
+        h + 60,
+        0,
+        w / 2,
+        h + 60,
+        h * 0.55
+      )
+      glow.addColorStop(0, `rgba(${TEAL}, ${0.05 + pulse * 0.06})`)
+      glow.addColorStop(1, `rgba(${TEAL}, 0)`)
+      ctx.fillStyle = glow
+      ctx.fillRect(0, 0, w, h)
+
+      // Rising psionic motes — soft glow via cheap two-pass circles
+      // (canvas shadowBlur is CPU-composited and too slow on mobile)
+      for (const m of motes) {
+        const x = m.x + Math.sin(t * 0.01 * m.sway + m.phase) * 14
+        ctx.beginPath()
+        ctx.arc(x, m.y, m.r * 3, 0, Math.PI * 2)
+        ctx.fillStyle = `rgba(${m.color}, ${m.alpha * 0.15})`
+        ctx.fill()
+        ctx.beginPath()
+        ctx.arc(x, m.y, m.r, 0, Math.PI * 2)
+        ctx.fillStyle = `rgba(${m.color}, ${m.alpha})`
+        ctx.fill()
+
+        if (!reduceMotion) {
+          m.y -= m.speed
+          if (m.y < -8) {
+            m.y = h + 8
+            m.x = Math.random() * w
+          }
+        }
+      }
+      t++
+    }
+
+    const loop = () => {
+      draw()
+      req = requestAnimationFrame(loop)
+    }
+
+    const start = () => {
+      if (running || reduceMotion) return
+      running = true
+      loop()
+    }
+    const stop = () => {
+      running = false
+      cancelAnimationFrame(req)
+    }
+
+    const onVisibility = () => {
+      if (document.hidden) stop()
+      else start()
+    }
+
+    // Debounced — raw resize fires per pixel of a window drag
+    const onResize = () => {
+      clearTimeout(resizeTimer)
+      resizeTimer = setTimeout(() => {
+        resize()
+        if (reduceMotion) draw()
+      }, 150)
+    }
+
+    resize()
+    window.addEventListener('resize', onResize)
+    document.addEventListener('visibilitychange', onVisibility)
+
+    if (reduceMotion) draw() // single static frame, no loop
+    else start()
+
+    return () => {
+      stop()
+      clearTimeout(resizeTimer)
+      window.removeEventListener('resize', onResize)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: -1,
+        pointerEvents: 'none'
+      }}
+    />
+  )
+}
+
+export default PsionicBackground

--- a/components/psionic-background.js
+++ b/components/psionic-background.js
@@ -7,9 +7,11 @@ import { useEffect, useRef } from 'react'
 // the tab is hidden. Accessibility: prefers-reduced-motion renders a
 // single static frame (no animation loop).
 
-const CYAN = '0, 221, 255'
-const TEAL = '0, 187, 221'
-const GOLD = '240, 192, 64' // khala gold accent
+import {
+  PROTOSS_CYAN_RGB as CYAN,
+  PROTOSS_TEAL_RGB as TEAL,
+  KHALA_GOLD_RGB as GOLD
+} from '../lib/site-theme-context'
 
 function createMotes(w, h) {
   const count = Math.min(80, Math.max(24, Math.floor((w * h) / 26000)))
@@ -37,8 +39,10 @@ const PsionicBackground = () => {
     let motes = []
     let req = null
     let running = false
-    let t = 0
     let resizeTimer = null
+    // Wall-clock time base — animation speed independent of refresh rate
+    const startTime = performance.now()
+    let lastTime = startTime
 
     const resize = () => {
       const dpr = Math.min(window.devicePixelRatio || 1, 2)
@@ -53,10 +57,14 @@ const PsionicBackground = () => {
     const draw = () => {
       const w = window.innerWidth
       const h = window.innerHeight
+      const now = performance.now()
+      const t = (now - startTime) * 0.001 // seconds
+      const dt = Math.min((now - lastTime) * 0.001, 0.1) // clamp resume jumps
+      lastTime = now
       ctx.clearRect(0, 0, w, h)
 
       // Pylon power glow — breathing radial pool rising from below
-      const pulse = reduceMotion ? 0.5 : 0.5 + Math.sin(t * 0.02) * 0.5
+      const pulse = reduceMotion ? 0.5 : 0.5 + Math.sin(t * 1.2) * 0.5
       const glow = ctx.createRadialGradient(
         w / 2,
         h + 60,
@@ -73,7 +81,7 @@ const PsionicBackground = () => {
       // Rising psionic motes — soft glow via cheap two-pass circles
       // (canvas shadowBlur is CPU-composited and too slow on mobile)
       for (const m of motes) {
-        const x = m.x + Math.sin(t * 0.01 * m.sway + m.phase) * 14
+        const x = m.x + Math.sin(t * 0.6 * m.sway + m.phase) * 14
         ctx.beginPath()
         ctx.arc(x, m.y, m.r * 3, 0, Math.PI * 2)
         ctx.fillStyle = `rgba(${m.color}, ${m.alpha * 0.15})`
@@ -84,14 +92,13 @@ const PsionicBackground = () => {
         ctx.fill()
 
         if (!reduceMotion) {
-          m.y -= m.speed
+          m.y -= m.speed * dt * 60 // speed tuned in px-per-60fps-frame units
           if (m.y < -8) {
             m.y = h + 8
             m.x = Math.random() * w
           }
         }
       }
-      t++
     }
 
     const loop = () => {

--- a/lib/site-theme-context.js
+++ b/lib/site-theme-context.js
@@ -1,30 +1,45 @@
-import { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback
+} from 'react'
 
 // Color palettes for each game theme
 export const PALETTES = {
   ffix: {
-    accent: '#c8a800',    // gold
-    text: '#f0e6a0',      // cream
+    accent: '#c8a800', // gold
+    text: '#f0e6a0', // cream
     panelBg: 'rgba(8, 14, 40, 0.97)',
     muted: '#9890a0',
     jobColor: '#bb77ff',
     headerBg: 'rgba(200,168,0,0.06)',
     headerBorder: '#c8a80044',
     itemBg: 'rgba(200,168,0,0.07)',
-    itemBorder: '#c8a80033',
+    itemBorder: '#c8a80033'
   },
   sc2: {
-    accent: '#00bbdd',    // protoss cyan
-    text: '#c0e8ff',      // light cyan
+    accent: '#00bbdd', // protoss cyan
+    text: '#c0e8ff', // light cyan
     panelBg: 'rgba(4, 12, 28, 0.97)',
     muted: '#7090a8',
     jobColor: '#00ddff',
     headerBg: 'rgba(0,187,221,0.06)',
     headerBorder: '#00bbdd44',
     itemBg: 'rgba(0,187,221,0.07)',
-    itemBorder: '#00bbdd33',
-  },
+    itemBorder: '#00bbdd33'
+  }
 }
+
+// Shared effect colors — single source for Protoss/FFIX glow accents.
+// RGB triplets are for rgba() templates, hex for style props.
+export const PROTOSS_CYAN = '#00ddff'
+export const PROTOSS_CYAN_RGB = '0, 221, 255'
+export const PROTOSS_TEAL_RGB = '0, 187, 221'
+export const KHALA_GOLD = '#f0c040'
+export const KHALA_GOLD_RGB = '240, 192, 64'
+export const FFIX_GOLD_RGB = '224, 192, 0'
 
 const SiteThemeContext = createContext({ theme: 'ffix', toggleTheme: () => {} })
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -25,7 +25,13 @@ import FfixTetraCards from '../components/ffix-tetra-card'
 import FfixEncounter from '../components/ffix-encounter'
 import FfixWorldMap from '../components/ffix-world-map'
 import ProtossWarpIn from '../components/protoss-warp-in'
-import { useSiteTheme } from '../lib/site-theme-context'
+import {
+  useSiteTheme,
+  PROTOSS_CYAN,
+  PROTOSS_CYAN_RGB,
+  KHALA_GOLD,
+  KHALA_GOLD_RGB
+} from '../lib/site-theme-context'
 
 // Resume timeline entries — keeps JSX clean
 const career = [
@@ -216,7 +222,7 @@ const Home = () => {
                       fontWeight={700}
                       textShadow={
                         theme === 'sc2'
-                          ? '0 0 18px rgba(0,221,255,0.5)'
+                          ? `0 0 18px rgba(${PROTOSS_CYAN_RGB}, 0.5)`
                           : 'none'
                       }
                     >
@@ -236,8 +242,8 @@ const Home = () => {
                         fontSize="xs"
                         fontFamily="mono"
                         letterSpacing="0.15em"
-                        color="#f0c040"
-                        textShadow="0 0 10px rgba(240,192,64,0.5)"
+                        color={KHALA_GOLD}
+                        textShadow={`0 0 10px rgba(${KHALA_GOLD_RGB}, 0.5)`}
                       >
                         ⟡ EN TARO ADUN — ENGINEER OF THE PROTOSS RACE ⟡
                       </Text>
@@ -379,10 +385,11 @@ const Home = () => {
                       fontSize="sm"
                       fontWeight={500}
                       _hover={{
-                        borderColor: theme === 'sc2' ? '#00ddff' : 'blue.400',
+                        borderColor:
+                          theme === 'sc2' ? PROTOSS_CYAN : 'blue.400',
                         boxShadow:
                           theme === 'sc2'
-                            ? '0 0 14px rgba(0,221,255,0.35)'
+                            ? `0 0 14px rgba(${PROTOSS_CYAN_RGB}, 0.35)`
                             : 'none'
                       }}
                       transition="border-color 0.2s, box-shadow 0.2s"

--- a/pages/index.js
+++ b/pages/index.js
@@ -24,42 +24,100 @@ import FfixMognet from '../components/ffix-mognet'
 import FfixTetraCards from '../components/ffix-tetra-card'
 import FfixEncounter from '../components/ffix-encounter'
 import FfixWorldMap from '../components/ffix-world-map'
+import ProtossWarpIn from '../components/protoss-warp-in'
 import { useSiteTheme } from '../lib/site-theme-context'
 
 // Resume timeline entries — keeps JSX clean
 const career = [
-  { year: 'Jan 2026–now', role: 'Head of Tech Partnership',    company: 'Ecomdy Media',           url: 'https://ecomdymedia.com/' },
-  { year: '2022–2025',    role: 'CTO',                         company: 'Ecomdy Media',           url: 'https://ecomdymedia.com/' },
-  { year: '2020–2022',    role: 'Technical Leader / Core Dev', company: 'NFQ Asia · Shopware',    url: 'https://nfq.asia/' },
-  { year: '2019–2020',    role: 'Technical Leader',            company: 'Ylinkee',                url: 'https://www.facebook.com/Ylinkee/' },
-  { year: '2018–2019',    role: 'Tech Lead / Product Manager', company: 'Dotmark Connect',        url: null },
-  { year: '2014–2017',    role: 'Branch Manager Vietnam',      company: 'Webpuppies Singapore',   url: 'https://webpuppies.com.sg/' },
-  { year: '2010–2014',    role: 'Senior Interactive Developer', company: 'Webpuppies Singapore',  url: 'https://webpuppies.com.sg/' },
-  { year: '2008–2010',    role: 'Interactive Web Developer',   company: 'Clearpath Development',  url: 'https://clearpathdevelopment.com/' },
-  { year: '2007–2008',    role: 'Frontend Web Developer',      company: 'Success Software',       url: 'https://successsoftware.global/' },
-  { year: '1987',         role: 'Born',                        company: 'Buon Ho, Daklak, Vietnam', url: null },
+  {
+    year: 'Jan 2026–now',
+    role: 'Head of Tech Partnership',
+    company: 'Ecomdy Media',
+    url: 'https://ecomdymedia.com/'
+  },
+  {
+    year: '2022–2025',
+    role: 'CTO',
+    company: 'Ecomdy Media',
+    url: 'https://ecomdymedia.com/'
+  },
+  {
+    year: '2020–2022',
+    role: 'Technical Leader / Core Dev',
+    company: 'NFQ Asia · Shopware',
+    url: 'https://nfq.asia/'
+  },
+  {
+    year: '2019–2020',
+    role: 'Technical Leader',
+    company: 'Ylinkee',
+    url: 'https://www.facebook.com/Ylinkee/'
+  },
+  {
+    year: '2018–2019',
+    role: 'Tech Lead / Product Manager',
+    company: 'Dotmark Connect',
+    url: null
+  },
+  {
+    year: '2014–2017',
+    role: 'Branch Manager Vietnam',
+    company: 'Webpuppies Singapore',
+    url: 'https://webpuppies.com.sg/'
+  },
+  {
+    year: '2010–2014',
+    role: 'Senior Interactive Developer',
+    company: 'Webpuppies Singapore',
+    url: 'https://webpuppies.com.sg/'
+  },
+  {
+    year: '2008–2010',
+    role: 'Interactive Web Developer',
+    company: 'Clearpath Development',
+    url: 'https://clearpathdevelopment.com/'
+  },
+  {
+    year: '2007–2008',
+    role: 'Frontend Web Developer',
+    company: 'Success Software',
+    url: 'https://successsoftware.global/'
+  },
+  { year: '1987', role: 'Born', company: 'Buon Ho, Daklak, Vietnam', url: null }
 ]
 
 const socialLinks = [
-  { icon: <IoLogoGithub />,    label: '@nguyenquangtin', href: 'https://github.com/nguyenquangtin' },
-  { icon: <IoLogoTwitter />,   label: '@nguyenquangtin', href: 'https://twitter.com/nguyenquangtin' },
-  { icon: <IoLogoInstagram />, label: '@tonytinnguyen',  href: 'https://instagram.com/tonytinnguyen' },
+  {
+    icon: <IoLogoGithub />,
+    label: '@nguyenquangtin',
+    href: 'https://github.com/nguyenquangtin'
+  },
+  {
+    icon: <IoLogoTwitter />,
+    label: '@nguyenquangtin',
+    href: 'https://twitter.com/nguyenquangtin'
+  },
+  {
+    icon: <IoLogoInstagram />,
+    label: '@tonytinnguyen',
+    href: 'https://instagram.com/tonytinnguyen'
+  }
 ]
 
 const TAGLINES = {
   ffix: 'engineer · entrepreneur · black mage',
-  sc2:  'engineer · entrepreneur · high templar',
+  sc2: 'engineer of the protoss · entrepreneur · high templar'
 }
 const SECTION_LABELS = {
   ffix: { charSheet: 'Character Sheet', mognet: 'Mognet' },
-  sc2:  { charSheet: 'Commander Profile', mognet: 'Khalai Comms' },
+  sc2: { charSheet: 'Commander Profile', mognet: 'Khalai Comms' }
 }
 
 const Home = () => {
   const { theme } = useSiteTheme()
-  const cardBg       = useColorModeValue('white', 'whiteAlpha.50')
-  const cardBorder   = useColorModeValue('gray.200', 'whiteAlpha.100')
-  const mutedText    = useColorModeValue('gray.500', 'gray.400')
+  const cardBg = useColorModeValue('white', 'whiteAlpha.50')
+  const cardBorder = useColorModeValue('gray.200', 'whiteAlpha.100')
+  const mutedText = useColorModeValue('gray.500', 'gray.400')
   const timelineLine = useColorModeValue('blue.400', 'blue.500')
 
   // ── Career sidebar (reused in both mobile stack and desktop sidebar)
@@ -90,9 +148,13 @@ const Home = () => {
               {entry.role}
             </Text>
             <Text fontSize="xs" color={mutedText}>
-              {entry.url
-                ? <Link href={entry.url} isExternal>{entry.company}</Link>
-                : entry.company}
+              {entry.url ? (
+                <Link href={entry.url} isExternal>
+                  {entry.company}
+                </Link>
+              ) : (
+                entry.company
+              )}
             </Text>
           </Box>
         ))}
@@ -105,19 +167,17 @@ const Home = () => {
       <FfixMoogleFlying />
       <FfixEncounter />
       <Layout>
-
-          {/* ── TWO-COLUMN DESKTOP LAYOUT ─────────────────── */}
-          <Flex
-            direction={{ base: 'column', lg: 'row' }}
-            align="flex-start"
-            gap={8}
-          >
-
-            {/* ── LEFT COLUMN — main content ─────────────── */}
-            <Box flex={3} minW={0}>
-
-              {/* HERO */}
-              <Section delay={0}>
+        {/* ── TWO-COLUMN DESKTOP LAYOUT ─────────────────── */}
+        <Flex
+          direction={{ base: 'column', lg: 'row' }}
+          align="flex-start"
+          gap={8}
+        >
+          {/* ── LEFT COLUMN — main content ─────────────── */}
+          <Box flex={3} minW={0}>
+            {/* HERO — warp-in reveal replays on theme switch via key */}
+            <Section delay={0}>
+              <ProtossWarpIn key={theme}>
                 <Flex
                   direction={{ base: 'column', md: 'row' }}
                   align="center"
@@ -143,17 +203,45 @@ const Home = () => {
                     </Box>
                     <Flex align="center" justify="center" mt={2} gap={1}>
                       <Box w={2} h={2} borderRadius="full" bg="green.400" />
-                      <Text fontSize="xs" color={mutedText}>Danang, Vietnam</Text>
+                      <Text fontSize="xs" color={mutedText}>
+                        Danang, Vietnam
+                      </Text>
                     </Flex>
                   </Box>
 
                   <Box flex={1}>
-                    <Heading as="h2" fontSize={{ base: '2xl', md: '3xl' }} fontWeight={700}>
+                    <Heading
+                      as="h2"
+                      fontSize={{ base: '2xl', md: '3xl' }}
+                      fontWeight={700}
+                      textShadow={
+                        theme === 'sc2'
+                          ? '0 0 18px rgba(0,221,255,0.5)'
+                          : 'none'
+                      }
+                    >
                       Tony Tin Nguyen
                     </Heading>
-                    <Text color={mutedText} mt={1} fontSize="sm" fontFamily="mono">
+                    <Text
+                      color={mutedText}
+                      mt={1}
+                      fontSize="sm"
+                      fontFamily="mono"
+                    >
                       {TAGLINES[theme]}
                     </Text>
+                    {theme === 'sc2' && (
+                      <Text
+                        mt={1}
+                        fontSize="xs"
+                        fontFamily="mono"
+                        letterSpacing="0.15em"
+                        color="#f0c040"
+                        textShadow="0 0 10px rgba(240,192,64,0.5)"
+                      >
+                        ⟡ EN TARO ADUN — ENGINEER OF THE PROTOSS RACE ⟡
+                      </Text>
+                    )}
                     <Box
                       mt={3}
                       p={3}
@@ -165,135 +253,175 @@ const Home = () => {
                       fontWeight={500}
                     >
                       Building products that scale - Head of Tech Partnership at{' '}
-                      <Link href="https://ecomdymedia.com/" isExternal color="blue.400">Ecomdy</Link>
+                      <Link
+                        href="https://ecomdymedia.com/"
+                        isExternal
+                        color="blue.400"
+                      >
+                        Ecomdy
+                      </Link>
                       , TikTok Marketing Partner & co-founder of{' '}
-                      <Link href="https://gdgmientrung.com/" isExternal color="blue.400">GDG Mien Trung</Link>.
+                      <Link
+                        href="https://gdgmientrung.com/"
+                        isExternal
+                        color="blue.400"
+                      >
+                        GDG Mien Trung
+                      </Link>
+                      .
                     </Box>
                   </Box>
                 </Flex>
-              </Section>
+              </ProtossWarpIn>
+            </Section>
 
-              {/* WORK */}
-              <Section delay={0.1}>
-                <Heading as="h3" variant="section-title">Work</Heading>
-                <Paragraph>
-                  19+ years shipping web products for global brands (BreadTalk, CooperVision) and
-                  fast-growing startups. Expert in JavaScript ecosystems - Node.js, React, Vue,
-                  TypeScript - with a focus on e-commerce, TikTok API integrations, and scalable architecture.
-                </Paragraph>
-                <Box mt={4} textAlign="center">
-                  <Button
-                    as={NextLink}
-                    href="/works"
-                    scroll={false}
-                    rightIcon={<ChevronRightIcon />}
-                    colorScheme="blue"
-                    size="sm"
-                  >
-                    View portfolio
-                  </Button>
-                </Box>
-              </Section>
-
-              {/* FFIX CHARACTER SHEET */}
-              <Section delay={0.15}>
-                <Heading as="h3" variant="section-title">{SECTION_LABELS[theme].charSheet}</Heading>
-                <FfixStatusEffects />
-                {/* 3-column row: CharSheet | Tech | Equipment */}
-                <SimpleGrid
-                  columns={{ base: 1, sm: 2 }}
-                  gap={4}
-                  alignItems="stretch"
-                  mt={3}
-                  sx={{
-                    '@media (min-width: 48em)': {
-                      gridTemplateColumns: '2fr 1.4fr 1.4fr',
-                    }
-                  }}
+            {/* WORK */}
+            <Section delay={0.1}>
+              <Heading as="h3" variant="section-title">
+                Work
+              </Heading>
+              <Paragraph>
+                19+ years shipping web products for global brands (BreadTalk,
+                CooperVision) and fast-growing startups. Expert in JavaScript
+                ecosystems - Node.js, React, Vue, TypeScript - with a focus on
+                e-commerce, TikTok API integrations, and scalable architecture.
+              </Paragraph>
+              <Box mt={4} textAlign="center">
+                <Button
+                  as={NextLink}
+                  href="/works"
+                  scroll={false}
+                  rightIcon={<ChevronRightIcon />}
+                  colorScheme="blue"
+                  size="sm"
                 >
-                  <FfixCharSheet />
-                  <FfixTechMenu />
-                  <FfixEquipment />
-                </SimpleGrid>
-                {/* Interest pills — full-width row below */}
-                <Box mt={4}>
-                  <FfixInterestTags />
-                </Box>
-              </Section>
-
-              {/* TETRA MASTER CARDS */}
-              <Section delay={0.25}>
-                <Heading as="h3" variant="section-title">Featured</Heading>
-                <FfixTetraCards />
-              </Section>
-
-              {/* CAREER — mobile only (shows inline in stack) */}
-              <Box display={{ base: 'block', lg: 'none' }}>
-                <Section delay={0.2}>
-                  <Heading as="h3" variant="section-title">Career</Heading>
-                  {CareerPanel}
-                </Section>
+                  View portfolio
+                </Button>
               </Box>
+            </Section>
 
-              {/* WORLD MAP */}
-              <Section delay={0.3}>
-                <Heading as="h3" variant="section-title">Location</Heading>
-                <FfixWorldMap />
-              </Section>
+            {/* FFIX CHARACTER SHEET */}
+            <Section delay={0.15}>
+              <Heading as="h3" variant="section-title">
+                {SECTION_LABELS[theme].charSheet}
+              </Heading>
+              <FfixStatusEffects />
+              {/* 3-column row: CharSheet | Tech | Equipment */}
+              <SimpleGrid
+                columns={{ base: 1, sm: 2 }}
+                gap={4}
+                alignItems="stretch"
+                mt={3}
+                sx={{
+                  '@media (min-width: 48em)': {
+                    gridTemplateColumns: '2fr 1.4fr 1.4fr'
+                  }
+                }}
+              >
+                <FfixCharSheet />
+                <FfixTechMenu />
+                <FfixEquipment />
+              </SimpleGrid>
+              {/* Interest pills — full-width row below */}
+              <Box mt={4}>
+                <FfixInterestTags />
+              </Box>
+            </Section>
 
-              {/* SOCIAL LINKS */}
-              <Section delay={0.35}>
-                <Heading as="h3" variant="section-title">On the web</Heading>
-                <Flex gap={3} wrap="wrap" mt={2}>
-                  {socialLinks.map(({ icon, label, href }) => (
-                    <Link key={href} href={href} isExternal _hover={{ textDecoration: 'none' }}>
-                      <Flex
-                        align="center"
-                        gap={2}
-                        px={3}
-                        py={2}
-                        borderRadius="lg"
-                        border="1px solid"
-                        borderColor={cardBorder}
-                        bg={cardBg}
-                        fontSize="sm"
-                        fontWeight={500}
-                        _hover={{ borderColor: 'blue.400' }}
-                        transition="border-color 0.2s"
-                        cursor="pointer"
-                      >
-                        {icon}
-                        <Text>{label}</Text>
-                      </Flex>
-                    </Link>
-                  ))}
-                </Flex>
-              </Section>
+            {/* TETRA MASTER CARDS */}
+            <Section delay={0.25}>
+              <Heading as="h3" variant="section-title">
+                Featured
+              </Heading>
+              <FfixTetraCards />
+            </Section>
 
-              {/* MOGNET — newsletter CTA */}
-              <Section delay={0.4}>
-                <Heading as="h3" variant="section-title">{SECTION_LABELS[theme].mognet}</Heading>
-                <FfixMognet />
-              </Section>
-
-            </Box>
-
-            {/* ── RIGHT COLUMN — sticky career (desktop only) ─ */}
-            <Box
-              flex={2}
-              minW="280px"
-              display={{ base: 'none', lg: 'block' }}
-              position="sticky"
-              top="80px"
-              alignSelf="flex-start"
-            >
+            {/* CAREER — mobile only (shows inline in stack) */}
+            <Box display={{ base: 'block', lg: 'none' }}>
               <Section delay={0.2}>
-                <Heading as="h3" variant="section-title">Career</Heading>
+                <Heading as="h3" variant="section-title">
+                  Career
+                </Heading>
                 {CareerPanel}
               </Section>
             </Box>
 
-          </Flex>
+            {/* WORLD MAP */}
+            <Section delay={0.3}>
+              <Heading as="h3" variant="section-title">
+                Location
+              </Heading>
+              <FfixWorldMap />
+            </Section>
+
+            {/* SOCIAL LINKS */}
+            <Section delay={0.35}>
+              <Heading as="h3" variant="section-title">
+                On the web
+              </Heading>
+              <Flex gap={3} wrap="wrap" mt={2}>
+                {socialLinks.map(({ icon, label, href }) => (
+                  <Link
+                    key={href}
+                    href={href}
+                    isExternal
+                    _hover={{ textDecoration: 'none' }}
+                  >
+                    <Flex
+                      align="center"
+                      gap={2}
+                      px={3}
+                      py={2}
+                      borderRadius="lg"
+                      border="1px solid"
+                      borderColor={cardBorder}
+                      bg={cardBg}
+                      fontSize="sm"
+                      fontWeight={500}
+                      _hover={{
+                        borderColor: theme === 'sc2' ? '#00ddff' : 'blue.400',
+                        boxShadow:
+                          theme === 'sc2'
+                            ? '0 0 14px rgba(0,221,255,0.35)'
+                            : 'none'
+                      }}
+                      transition="border-color 0.2s, box-shadow 0.2s"
+                      cursor="pointer"
+                    >
+                      {icon}
+                      <Text>{label}</Text>
+                    </Flex>
+                  </Link>
+                ))}
+              </Flex>
+            </Section>
+
+            {/* MOGNET — newsletter CTA */}
+            <Section delay={0.4}>
+              <Heading as="h3" variant="section-title">
+                {SECTION_LABELS[theme].mognet}
+              </Heading>
+              <FfixMognet />
+            </Section>
+          </Box>
+
+          {/* ── RIGHT COLUMN — sticky career (desktop only) ─ */}
+          <Box
+            flex={2}
+            minW="280px"
+            display={{ base: 'none', lg: 'block' }}
+            position="sticky"
+            top="80px"
+            alignSelf="flex-start"
+          >
+            <Section delay={0.2}>
+              <Heading as="h3" variant="section-title">
+                Career
+              </Heading>
+              {CareerPanel}
+            </Section>
+          </Box>
+        </Flex>
       </Layout>
     </>
   )


### PR DESCRIPTION
## Summary
StarCraft II Protoss "wow" animation overhaul for the existing SC2 site theme. Frames Tony as an **Engineer of the Protoss race** and makes the SC2 mode shine with heavy, cinematic psionic effects — all gated so the FFIX theme is untouched.

Closes #4

## Changes
**New components**
- `components/protoss-warp-in.js` — warp-in reveal (blur + overbright shimmer + psionic glow flare); replays on theme switch via `key={theme}`; renders plain children in FFIX / reduced motion
- `components/psionic-background.js` — full-viewport canvas: rising cyan/gold psionic motes + breathing Pylon power glow; pauses on hidden tab, DPR capped at 2, mote count scales with viewport

**Enhanced**
- `pages/index.js` — hero wrapped in warp-in; cyan glow on name; gold "⟡ EN TARO ADUN — ENGINEER OF THE PROTOSS RACE ⟡" badge; SC2 tagline update; plasma-shield hover on social links
- `components/game-theme-toggle.js` — full-screen warp flash on toggle (cyan → SC2, gold → FFIX); double-click guard
- `components/protoss-pylon.js` — expanding power-field shockwave ring (2.4s loop) + crystal emissive throb; GPU buffer disposal on unmount
- `components/layouts/main.js` — mounts psionic background (SC2-gated, `ssr: false`)

No new dependencies — built on existing `framer-motion` + `three`.

## Verification
- [x] `next lint` clean (only pre-existing warning in untouched `battle-scene.js`)
- [x] `next build` passes — homepage bundle unchanged (14.3 kB / 216 kB first load)
- [x] Code review: 0 blockers / 0 majors; review fixes applied (mobile canvas perf, debounced resize, Three.js disposal, a11y)
- [x] `prefers-reduced-motion` degrades all effects gracefully
- [x] FFIX theme regression-free (every effect gated on `theme === 'sc2'`)

## Deferred
- Color constant centralization (`#00ddff` / `#f0c040` repeated across files) — reviewer-rated minor, cosmetic
