### PR TITLE
feat: SC2 command-console UI across all pages, hide FFIX theme

### DIFF
--- a/components/ffix-tetra-card.js
+++ b/components/ffix-tetra-card.js
@@ -1,7 +1,7 @@
 import { Box, Text, Flex, SimpleGrid } from '@chakra-ui/react'
 import { motion } from 'framer-motion'
 
-const GOLD = '#c8a800'
+const GOLD = '#00bbdd' // SC2 accent while FFIX is hidden (#7); was '#c8a800'
 const PANEL_BG = 'rgba(8, 14, 40, 0.97)'
 
 // Project cards styled as FFIX Tetra Master cards
@@ -12,34 +12,49 @@ const CARDS = [
     type: 'LEGEND',
     art: 'linear-gradient(135deg, #1a0a3a 0%, #3a1a6a 50%, #1a0a3a 100%)',
     glow: '#aa66ff',
-    A: 9, P: 6, M: 8, X: 9,
+    A: 9,
+    P: 6,
+    M: 8,
+    X: 9
   },
   {
     name: 'Coder\nHorizon',
     type: 'RARE',
     art: 'linear-gradient(135deg, #0a1a3a 0%, #1a4a6a 50%, #0a1a3a 100%)',
     glow: '#44ccff',
-    A: 7, P: 5, M: 9, X: 8,
+    A: 7,
+    P: 5,
+    M: 9,
+    X: 8
   },
   {
     name: 'GDG\nMien Trung',
     type: 'RARE',
     art: 'linear-gradient(135deg, #0a2a1a 0%, #1a5a2a 50%, #0a2a1a 100%)',
     glow: '#00cc55',
-    A: 6, P: 7, M: 7, X: 9,
+    A: 6,
+    P: 7,
+    M: 7,
+    X: 9
   },
   {
     name: 'NFQ Asia\nShopware',
     type: 'COMMON',
     art: 'linear-gradient(135deg, #2a1a0a 0%, #5a3a1a 50%, #2a1a0a 100%)',
     glow: '#ffcc00',
-    A: 8, P: 8, M: 6, X: 7,
-  },
+    A: 8,
+    P: 8,
+    M: 6,
+    X: 7
+  }
 ]
 
 // Single Tetra Master card
 const TetraCard = ({ card }) => (
-  <motion.div whileHover={{ scale: 1.05, rotate: 1 }} transition={{ duration: 0.2 }}>
+  <motion.div
+    whileHover={{ scale: 1.05, rotate: 1 }}
+    transition={{ duration: 0.2 }}
+  >
     <Box
       bg={PANEL_BG}
       border={`2px solid ${card.glow}66`}
@@ -49,21 +64,29 @@ const TetraCard = ({ card }) => (
       fontFamily="monospace"
       cursor="pointer"
       position="relative"
-      _hover={{ boxShadow: `0 0 0 1px rgba(8,14,40,0.9), 0 0 20px ${card.glow}44` }}
+      _hover={{
+        boxShadow: `0 0 0 1px rgba(8,14,40,0.9), 0 0 20px ${card.glow}44`
+      }}
       transition="box-shadow 0.2s"
     >
       {/* Card art area */}
       <Box h="80px" background={card.art} position="relative">
         {/* Corner A value (top-left) */}
         <Text
-          position="absolute" top={1} left={2}
-          fontSize="14px" fontWeight="bold" color={card.glow}
+          position="absolute"
+          top={1}
+          left={2}
+          fontSize="14px"
+          fontWeight="bold"
+          color={card.glow}
         >
           {card.A}
         </Text>
         {/* Type badge */}
         <Box position="absolute" top={1} right={2}>
-          <Text fontSize="8px" color={`${card.glow}bb`} letterSpacing="0.1em">{card.type}</Text>
+          <Text fontSize="8px" color={`${card.glow}bb`} letterSpacing="0.1em">
+            {card.type}
+          </Text>
         </Box>
         {/* Decorative crystal shape */}
         <Box
@@ -93,10 +116,18 @@ const TetraCard = ({ card }) => (
           {card.name}
         </Text>
         <Flex justify="space-between">
-          {[['P', card.P], ['M', card.M], ['X', card.X]].map(([k, v]) => (
+          {[
+            ['P', card.P],
+            ['M', card.M],
+            ['X', card.X]
+          ].map(([k, v]) => (
             <Flex key={k} align="baseline" gap="2px">
-              <Text fontSize="8px" color={GOLD}>{k}</Text>
-              <Text fontSize="11px" fontWeight="bold" color={card.glow}>{v}</Text>
+              <Text fontSize="8px" color={GOLD}>
+                {k}
+              </Text>
+              <Text fontSize="11px" fontWeight="bold" color={card.glow}>
+                {v}
+              </Text>
             </Flex>
           ))}
         </Flex>
@@ -114,11 +145,20 @@ const FfixTetraCards = () => (
     overflow="hidden"
     fontFamily="monospace"
   >
-    <Box px={3} py={2} bg="rgba(200,168,0,0.06)" borderBottom={`1px solid ${GOLD}44`}>
-      <Text fontSize="10px" color={GOLD} letterSpacing="0.15em">◆ TETRA MASTER — PROJECT CARDS</Text>
+    <Box
+      px={3}
+      py={2}
+      bg="rgba(0,187,221,0.06)"
+      borderBottom={`1px solid ${GOLD}44`}
+    >
+      <Text fontSize="10px" color={GOLD} letterSpacing="0.15em">
+        ◆ TETRA MASTER — PROJECT CARDS
+      </Text>
     </Box>
     <SimpleGrid columns={{ base: 2, sm: 4 }} gap={3} p={3}>
-      {CARDS.map(card => <TetraCard key={card.name} card={card} />)}
+      {CARDS.map(card => (
+        <TetraCard key={card.name} card={card} />
+      ))}
     </SimpleGrid>
     <Box px={3} pb={2}>
       <Text fontSize="9px" color="#9890a0" letterSpacing="0.08em">

--- a/components/ffix-world-map.js
+++ b/components/ffix-world-map.js
@@ -2,8 +2,8 @@ import { Box, Text, Flex } from '@chakra-ui/react'
 import { motion } from 'framer-motion'
 
 const PANEL_BG = 'rgba(8, 14, 40, 0.97)'
-const GOLD  = '#c8a800'
-const LAND  = '#1a3a2a'
+const GOLD = '#00bbdd' // SC2 accent while FFIX is hidden (#7); was '#c8a800'
+const LAND = '#1a3a2a'
 const OCEAN = PANEL_BG
 
 // Simplified world map paths in a 700×320 viewBox (Mercator-ish)
@@ -30,7 +30,7 @@ const CONTINENTS = [
   // Australia
   'M 538 238 L 612 228 L 628 258 L 618 294 L 574 302 L 538 282 L 528 260 Z',
   // UK/Ireland
-  'M 280 64 L 294 60 L 298 80 L 285 84 Z',
+  'M 280 64 L 294 60 L 298 80 L 285 84 Z'
 ]
 
 // Danang coordinates in the same projection
@@ -46,11 +46,22 @@ const FfixWorldMap = () => (
     fontFamily="monospace"
   >
     {/* Header */}
-    <Flex px={3} py={2} bg="rgba(200,168,0,0.06)" borderBottom={`1px solid ${GOLD}44`} justify="space-between" align="center">
-      <Text fontSize="10px" color={GOLD} letterSpacing="0.15em">◆ WORLD MAP</Text>
+    <Flex
+      px={3}
+      py={2}
+      bg="rgba(0,187,221,0.06)"
+      borderBottom={`1px solid ${GOLD}44`}
+      justify="space-between"
+      align="center"
+    >
+      <Text fontSize="10px" color={GOLD} letterSpacing="0.15em">
+        ◆ WORLD MAP
+      </Text>
       <Flex align="center" gap={1}>
         <Box w={2} h={2} borderRadius="full" bg="green.400" />
-        <Text fontSize="9px" color="#9890a0">DANANG, VIETNAM</Text>
+        <Text fontSize="9px" color="#9890a0">
+          DANANG, VIETNAM
+        </Text>
       </Flex>
     </Flex>
 
@@ -63,15 +74,38 @@ const FfixWorldMap = () => (
       >
         {/* Ocean grid lines */}
         {[...Array(8)].map((_, i) => (
-          <line key={`h${i}`} x1="0" y1={i * 40} x2="700" y2={i * 40} stroke="#ffffff06" strokeWidth="0.5" />
+          <line
+            key={`h${i}`}
+            x1="0"
+            y1={i * 40}
+            x2="700"
+            y2={i * 40}
+            stroke="#ffffff06"
+            strokeWidth="0.5"
+          />
         ))}
         {[...Array(14)].map((_, i) => (
-          <line key={`v${i}`} x1={i * 50} y1="0" x2={i * 50} y2="320" stroke="#ffffff06" strokeWidth="0.5" />
+          <line
+            key={`v${i}`}
+            x1={i * 50}
+            y1="0"
+            x2={i * 50}
+            y2="320"
+            stroke="#ffffff06"
+            strokeWidth="0.5"
+          />
         ))}
 
         {/* Continents */}
         {CONTINENTS.map((d, i) => (
-          <path key={i} d={d} fill={LAND} stroke="#2a5a3a" strokeWidth="0.8" opacity={0.9} />
+          <path
+            key={i}
+            d={d}
+            fill={LAND}
+            stroke="#2a5a3a"
+            strokeWidth="0.8"
+            opacity={0.9}
+          />
         ))}
 
         {/* Danang — outer pulse ring */}

--- a/components/footer.js
+++ b/components/footer.js
@@ -4,39 +4,80 @@ import { motion } from 'framer-motion'
 const Footer = () => {
   return (
     <Box mt={10} mb={4} textAlign="center">
-      {/* FFIX Save Point */}
+      {/* SC2 Pylon beacon (#7) */}
       <Flex direction="column" align="center" gap={1.5}>
-        {/* Pulsing crystal */}
+        {/* Pulsing khaydarin crystal */}
         <motion.div
           animate={{ opacity: [0.5, 1, 0.5], scale: [0.95, 1.05, 0.95] }}
           transition={{ repeat: Infinity, duration: 3, ease: 'easeInOut' }}
           style={{ display: 'inline-block' }}
         >
-          <svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg">
+          <svg
+            width="28"
+            height="28"
+            viewBox="0 0 28 28"
+            xmlns="http://www.w3.org/2000/svg"
+          >
             {/* Outer glow ring */}
-            <circle cx="14" cy="14" r="13" fill="none" stroke="#00aaff" strokeWidth="0.6" opacity="0.4" />
+            <circle
+              cx="14"
+              cy="14"
+              r="13"
+              fill="none"
+              stroke="#00ddff"
+              strokeWidth="0.6"
+              opacity="0.4"
+            />
             {/* Crystal gem shape */}
-            <polygon points="14,3 22,10 22,18 14,25 6,18 6,10" fill="#001a33" stroke="#00aaff" strokeWidth="1.2" />
+            <polygon
+              points="14,3 22,10 22,18 14,25 6,18 6,10"
+              fill="#001a33"
+              stroke="#00ddff"
+              strokeWidth="1.2"
+            />
             <polygon points="14,3 22,10 14,14" fill="#004488" opacity="0.8" />
-            <polygon points="14,3 6,10 14,14"  fill="#0066bb" opacity="0.6" />
-            <polygon points="6,10 6,18 14,14"  fill="#002255" opacity="0.9" />
+            <polygon points="14,3 6,10 14,14" fill="#0066bb" opacity="0.6" />
+            <polygon points="6,10 6,18 14,14" fill="#002255" opacity="0.9" />
             <polygon points="22,10 22,18 14,14" fill="#003366" opacity="0.7" />
-            <polygon points="6,18 14,25 14,14"  fill="#001a44" opacity="0.8" />
+            <polygon points="6,18 14,25 14,14" fill="#001a44" opacity="0.8" />
             <polygon points="22,18 14,25 14,14" fill="#002244" opacity="0.6" />
             {/* Shine */}
             <polygon points="14,3 18,8 14,9 10,8" fill="white" opacity="0.25" />
           </svg>
         </motion.div>
 
-        <Text fontFamily="monospace" fontSize="9px" color="#00aaff" letterSpacing="0.18em" opacity={0.8}>
-          ◆ SAVE POINT ◆
+        <Text
+          fontFamily="monospace"
+          fontSize="9px"
+          color="#00ddff"
+          letterSpacing="0.18em"
+          opacity={0.8}
+        >
+          ⟡ PYLON BEACON — EN TARO ADUN ⟡
         </Text>
-        <Text fontFamily="monospace" fontSize="9px" color="#4a6080" letterSpacing="0.08em">
-          &copy; {new Date().getFullYear()} Tony Tin Nguyen — All rights reserved
+        <Text
+          fontFamily="monospace"
+          fontSize="9px"
+          color="#4a6080"
+          letterSpacing="0.08em"
+        >
+          &copy; {new Date().getFullYear()} Tony Tin Nguyen — All rights
+          reserved
         </Text>
-        <Text fontFamily="monospace" fontSize="8px" color="#3a5060" letterSpacing="0.06em" opacity={0.7}>
+        <Text
+          fontFamily="monospace"
+          fontSize="8px"
+          color="#3a5060"
+          letterSpacing="0.06em"
+          opacity={0.7}
+        >
           Originally inspired by{' '}
-          <a href="https://www.craftz.dog/" target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'underline' }}>
+          <a
+            href="https://www.craftz.dog/"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ textDecoration: 'underline' }}
+          >
             Takuya Matsuyama
           </a>
         </Text>

--- a/components/grid-item.js
+++ b/components/grid-item.js
@@ -2,10 +2,47 @@ import NextLink from 'next/link'
 import Image from 'next/image'
 import { Box, Text, LinkBox, LinkOverlay } from '@chakra-ui/react'
 import { Global } from '@emotion/react'
+import { Sc2CornerBrackets } from './sc2/sc2-panel'
+import { PROTOSS_CYAN_RGB } from '../lib/site-theme-context'
+
+// SC2 command-card slot styling shared by both grid variants:
+// dark navy slot, luminous border, hover = corner brackets + psionic glow
+const cardSlotProps = {
+  role: 'group',
+  position: 'relative',
+  display: 'block',
+  bg: 'rgba(4, 12, 28, 0.85)',
+  border: `1px solid rgba(${PROTOSS_CYAN_RGB}, 0.25)`,
+  borderRadius: '4px',
+  p: 3,
+  cursor: 'pointer',
+  transition: 'all 0.2s',
+  _hover: {
+    borderColor: `rgba(${PROTOSS_CYAN_RGB}, 0.7)`,
+    boxShadow: `0 0 18px rgba(${PROTOSS_CYAN_RGB}, 0.25), inset 0 0 14px rgba(${PROTOSS_CYAN_RGB}, 0.06)`
+  }
+}
+
+const cardTitleProps = {
+  mt: 2,
+  fontFamily: 'mono',
+  fontSize: 'sm',
+  fontWeight: 'bold',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  color: '#c0e8ff'
+}
+
+const cardDescProps = {
+  fontSize: '13px',
+  color: '#7090a8',
+  mt: 1
+}
 
 export const GridItem = ({ children, href, title, thumbnail }) => (
   <Box w="100%" textAlign="center">
-    <LinkBox cursor="pointer">
+    <LinkBox {...cardSlotProps}>
+      <Sc2CornerBrackets hoverReveal />
       <Image
         src={thumbnail}
         alt={title}
@@ -14,9 +51,9 @@ export const GridItem = ({ children, href, title, thumbnail }) => (
         loading="lazy"
       />
       <LinkOverlay href={href} target="_blank">
-        <Text mt={2}>{title}</Text>
+        <Text {...cardTitleProps}>{title}</Text>
       </LinkOverlay>
-      <Text fontSize={14}>{children}</Text>
+      <Text {...cardDescProps}>{children}</Text>
     </LinkBox>
   </Box>
 )
@@ -33,8 +70,9 @@ export const WorkGridItem = ({
       as={NextLink}
       href={`/${category}/${id}`}
       scroll={false}
-      cursor="pointer"
+      {...cardSlotProps}
     >
+      <Sc2CornerBrackets hoverReveal />
       <Image
         src={thumbnail}
         alt={title}
@@ -42,20 +80,26 @@ export const WorkGridItem = ({
         placeholder="blur"
       />
       <LinkOverlay as="div" href={`/${category}/${id}`}>
-        <Text mt={2} fontSize={20}>
+        <Text {...cardTitleProps} fontSize="md">
           {title}
         </Text>
       </LinkOverlay>
-      <Text fontSize={14}>{children}</Text>
+      <Text {...cardDescProps}>{children}</Text>
     </LinkBox>
   </Box>
 )
 
+// Thumbnails idle slightly dimmed, brighten when the card slot is hovered
 export const GridItemStyle = () => (
   <Global
     styles={`
       .grid-item-thumbnail {
-        border-radius: 12px;
+        border-radius: 2px;
+        filter: brightness(0.88);
+        transition: filter 0.2s ease;
+      }
+      [role='group']:hover .grid-item-thumbnail {
+        filter: brightness(1.05);
       }
     `}
   />

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -43,6 +43,11 @@ const LinkItem = ({ href, path, target, children, ...props }) => {
         color: '#c0e8ff',
         textShadow: `0 0 8px rgba(${PROTOSS_CYAN_RGB}, 0.6)`
       }}
+      _focusVisible={{
+        color: '#c0e8ff',
+        outline: `2px solid ${PROTOSS_CYAN}`,
+        outlineOffset: '2px'
+      }}
       transition="all 0.15s"
       target={target}
       {...props}
@@ -120,13 +125,31 @@ const Navbar = props => {
                 fontFamily="mono"
                 fontSize="sm"
               >
-                <MenuItem as={MenuLink} href="/" bg="transparent">
+                <MenuItem
+                  as={MenuLink}
+                  href="/"
+                  bg="transparent"
+                  color="#c0e8ff"
+                  _hover={{ bg: `rgba(${PROTOSS_CYAN_RGB}, 0.12)` }}
+                >
                   About
                 </MenuItem>
-                <MenuItem as={MenuLink} href="/works" bg="transparent">
+                <MenuItem
+                  as={MenuLink}
+                  href="/works"
+                  bg="transparent"
+                  color="#c0e8ff"
+                  _hover={{ bg: `rgba(${PROTOSS_CYAN_RGB}, 0.12)` }}
+                >
                   Works
                 </MenuItem>
-                <MenuItem as={MenuLink} href="/posts" bg="transparent">
+                <MenuItem
+                  as={MenuLink}
+                  href="/posts"
+                  bg="transparent"
+                  color="#c0e8ff"
+                  _hover={{ bg: `rgba(${PROTOSS_CYAN_RGB}, 0.12)` }}
+                >
                   Blog
                 </MenuItem>
               </MenuList>

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -12,25 +12,38 @@ import {
   MenuItem,
   MenuList,
   MenuButton,
-  IconButton,
-  useColorModeValue
+  IconButton
 } from '@chakra-ui/react'
 import { HamburgerIcon } from '@chakra-ui/icons'
-import ThemeToggleButton from './theme-toggle-button'
-import GameThemeToggle from './game-theme-toggle'
-// import { IoLogoGithub } from 'react-icons/io5'
+import { PROTOSS_CYAN, PROTOSS_CYAN_RGB } from '../lib/site-theme-context'
+// GameThemeToggle + ThemeToggleButton removed while FFIX is hidden (#7) —
+// site is locked to the SC2 dark console look. Components kept for re-enable.
 
+// Console tab link (SC2 menu style): uppercase mono, cyan glow when active
 const LinkItem = ({ href, path, target, children, ...props }) => {
   const active = path === href
-  const inactiveColor = useColorModeValue('gray.800', 'whiteAlpha.900')
   return (
     <Link
       as={NextLink}
       href={href}
       scroll={false}
-      p={2}
-      bg={active ? 'grassTeal' : undefined}
-      color={active ? '#ffffff' : inactiveColor}
+      px={3}
+      py={2}
+      fontFamily="mono"
+      fontSize="xs"
+      fontWeight="bold"
+      textTransform="uppercase"
+      letterSpacing="0.12em"
+      color={active ? '#eafcff' : '#8fb8cc'}
+      bg={active ? `rgba(${PROTOSS_CYAN_RGB}, 0.14)` : undefined}
+      boxShadow={active ? `inset 0 -2px 0 ${PROTOSS_CYAN}` : undefined}
+      textShadow={active ? `0 0 10px rgba(${PROTOSS_CYAN_RGB}, 0.7)` : 'none'}
+      _hover={{
+        textDecoration: 'none',
+        color: '#c0e8ff',
+        textShadow: `0 0 8px rgba(${PROTOSS_CYAN_RGB}, 0.6)`
+      }}
+      transition="all 0.15s"
       target={target}
       {...props}
     >
@@ -51,7 +64,9 @@ const Navbar = props => {
       position="fixed"
       as="nav"
       w="100%"
-      bg={useColorModeValue('#f7f7f740', '#18181b80')}
+      bg="rgba(4, 10, 24, 0.85)"
+      borderBottom={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.25)`}
+      boxShadow={`0 0 18px rgba(${PROTOSS_CYAN_RGB}, 0.12)`}
       css={{ backdropFilter: 'blur(10px)' }}
       zIndex={2}
       {...props}
@@ -77,53 +92,43 @@ const Navbar = props => {
           alignItems="center"
           flexGrow={1}
           mt={{ base: 4, md: 0 }}
+          spacing={1}
         >
-           <LinkItem href="/works" path={path}>
+          <LinkItem href="/works" path={path}>
             Works
           </LinkItem>
           <LinkItem href="/posts" path={path}>
             Blog
           </LinkItem>
-          {/*
-          <LinkItem href="/posts" path={path}>
-            Posts
-          </LinkItem>
-          <LinkItem href="https://uses.craftz.dog/">Uses</LinkItem>
-  */}
         </Stack>
 
         <Box flex={1} align="right">
-          <GameThemeToggle />
-          <ThemeToggleButton />
-
           <Box ml={2} display={{ base: 'inline-block', md: 'none' }}>
             <Menu isLazy id="navbar-menu">
               <MenuButton
                 as={IconButton}
                 icon={<HamburgerIcon />}
                 variant="outline"
+                borderColor={`rgba(${PROTOSS_CYAN_RGB}, 0.45)`}
+                color="#c0e8ff"
+                _hover={{ bg: `rgba(${PROTOSS_CYAN_RGB}, 0.12)` }}
                 aria-label="Options"
               />
-              <MenuList>
-                <MenuItem as={MenuLink} href="/">
+              <MenuList
+                bg="rgba(4, 12, 28, 0.97)"
+                borderColor={`rgba(${PROTOSS_CYAN_RGB}, 0.35)`}
+                fontFamily="mono"
+                fontSize="sm"
+              >
+                <MenuItem as={MenuLink} href="/" bg="transparent">
                   About
                 </MenuItem>
-                <MenuItem as={MenuLink} href="/works">
+                <MenuItem as={MenuLink} href="/works" bg="transparent">
                   Works
                 </MenuItem>
-                <MenuItem as={MenuLink} href="/posts">
+                <MenuItem as={MenuLink} href="/posts" bg="transparent">
                   Blog
                 </MenuItem>
-                {/*
-                <MenuItem as={MenuLink} href="/wallpapers">
-                  Wallpapers
-                </MenuItem>
-                <MenuItem as={MenuLink} href="/posts">
-                  Posts
-                </MenuItem>
-                <MenuItem as={MenuLink} href="https://uses.craftz.dog/">
-                  Uses
-                </MenuItem>  */}
               </MenuList>
             </Menu>
           </Box>

--- a/components/sc2/sc2-button.js
+++ b/components/sc2/sc2-button.js
@@ -34,7 +34,6 @@ const Sc2Button = ({ variant = 'cyan', children, ...rest }) => {
       bg={`rgba(${v.rgb}, 0.12)`}
       border="1px solid"
       borderColor={`rgba(${v.rgb}, 0.55)`}
-      borderRadius="2px"
       clipPath="polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px)"
       boxShadow={`inset 0 0 12px rgba(${v.rgb}, 0.18)`}
       _hover={{
@@ -44,6 +43,12 @@ const Sc2Button = ({ variant = 'cyan', children, ...rest }) => {
         textShadow: `0 0 8px rgba(${v.rgb}, 0.8)`
       }}
       _active={{ transform: 'scale(0.97)' }}
+      // inset focus ring — outlines/shadows outside the box get clipped
+      // by clipPath, so keyboard focus must render inside (WCAG 2.4.7)
+      _focusVisible={{
+        outline: 'none',
+        boxShadow: `inset 0 0 0 2px rgba(${v.rgb}, 0.9), inset 0 0 16px rgba(${v.rgb}, 0.4)`
+      }}
       transition="all 0.15s"
       {...rest}
     >

--- a/components/sc2/sc2-button.js
+++ b/components/sc2/sc2-button.js
@@ -1,0 +1,55 @@
+import { Button } from '@chakra-ui/react'
+import { PROTOSS_CYAN_RGB, KHALA_GOLD_RGB } from '../../lib/site-theme-context'
+
+// Beveled console button (SC2 lobby style): clipped corners, inner glow.
+// Variants: cyan (default action), gold (primary CTA), green (confirm/active).
+const VARIANTS = {
+  cyan: {
+    rgb: PROTOSS_CYAN_RGB,
+    color: '#c0e8ff',
+    hoverColor: '#eafcff'
+  },
+  gold: {
+    rgb: KHALA_GOLD_RGB,
+    color: '#ffe8b0',
+    hoverColor: '#fff6dd'
+  },
+  green: {
+    rgb: '48, 216, 96',
+    color: '#c8ffd8',
+    hoverColor: '#eaffee'
+  }
+}
+
+const Sc2Button = ({ variant = 'cyan', children, ...rest }) => {
+  const v = VARIANTS[variant] || VARIANTS.cyan
+  return (
+    <Button
+      fontFamily="mono"
+      fontSize="xs"
+      fontWeight="bold"
+      letterSpacing="0.12em"
+      textTransform="uppercase"
+      color={v.color}
+      bg={`rgba(${v.rgb}, 0.12)`}
+      border="1px solid"
+      borderColor={`rgba(${v.rgb}, 0.55)`}
+      borderRadius="2px"
+      clipPath="polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px)"
+      boxShadow={`inset 0 0 12px rgba(${v.rgb}, 0.18)`}
+      _hover={{
+        bg: `rgba(${v.rgb}, 0.24)`,
+        color: v.hoverColor,
+        boxShadow: `inset 0 0 20px rgba(${v.rgb}, 0.35)`,
+        textShadow: `0 0 8px rgba(${v.rgb}, 0.8)`
+      }}
+      _active={{ transform: 'scale(0.97)' }}
+      transition="all 0.15s"
+      {...rest}
+    >
+      {children}
+    </Button>
+  )
+}
+
+export default Sc2Button

--- a/components/sc2/sc2-panel.js
+++ b/components/sc2/sc2-panel.js
@@ -1,0 +1,114 @@
+import { Box, Flex, Text } from '@chakra-ui/react'
+import {
+  PALETTES,
+  PROTOSS_CYAN,
+  PROTOSS_CYAN_RGB
+} from '../../lib/site-theme-context'
+
+const sc2 = PALETTES.sc2
+
+// Four corner brackets — SC2 selection frame (white angles on the active
+// card). Render inside a position:relative parent. With `hoverReveal` the
+// brackets stay hidden until the parent (role="group") is hovered.
+export const Sc2CornerBrackets = ({
+  hoverReveal = false,
+  size = '14px',
+  color = '#e8f8ff'
+}) => (
+  <>
+    {[
+      {
+        top: '-2px',
+        left: '-2px',
+        borderTopWidth: '2px',
+        borderLeftWidth: '2px'
+      },
+      {
+        top: '-2px',
+        right: '-2px',
+        borderTopWidth: '2px',
+        borderRightWidth: '2px'
+      },
+      {
+        bottom: '-2px',
+        left: '-2px',
+        borderBottomWidth: '2px',
+        borderLeftWidth: '2px'
+      },
+      {
+        bottom: '-2px',
+        right: '-2px',
+        borderBottomWidth: '2px',
+        borderRightWidth: '2px'
+      }
+    ].map((pos, i) => (
+      <Box
+        key={i}
+        aria-hidden
+        position="absolute"
+        w={size}
+        h={size}
+        borderColor={color}
+        borderStyle="solid"
+        borderWidth="0"
+        opacity={hoverReveal ? 0 : 1}
+        _groupHover={hoverReveal ? { opacity: 1 } : undefined}
+        transition="opacity 0.15s"
+        pointerEvents="none"
+        zIndex={1}
+        {...pos}
+      />
+    ))}
+  </>
+)
+
+// Command-console panel: dark navy body, luminous double border, inner
+// psionic glow, optional angular header bar with title + right-side meta.
+const Sc2Panel = ({
+  title,
+  meta,
+  brackets = false,
+  unpadded = false,
+  children,
+  ...rest
+}) => (
+  <Box
+    position="relative"
+    role={brackets ? 'group' : undefined}
+    bg={sc2.panelBg}
+    border={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.35)`}
+    borderRadius="4px"
+    boxShadow={`inset 0 0 24px rgba(${PROTOSS_CYAN_RGB}, 0.07), 0 0 0 3px rgba(4, 12, 28, 0.8), 0 0 0 4px rgba(${PROTOSS_CYAN_RGB}, 0.15)`}
+    {...rest}
+  >
+    {brackets && <Sc2CornerBrackets hoverReveal />}
+    {title && (
+      <Flex
+        px={4}
+        py={2}
+        bg={sc2.headerBg}
+        borderBottom={`1px solid ${sc2.headerBorder}`}
+        justify="space-between"
+        align="center"
+      >
+        <Text
+          fontFamily="mono"
+          fontSize="10px"
+          color={PROTOSS_CYAN}
+          letterSpacing="0.15em"
+          textTransform="uppercase"
+        >
+          ▸ {title}
+        </Text>
+        {meta && (
+          <Text fontFamily="mono" fontSize="10px" color={sc2.muted}>
+            {meta}
+          </Text>
+        )}
+      </Flex>
+    )}
+    {unpadded ? children : <Box p={4}>{children}</Box>}
+  </Box>
+)
+
+export default Sc2Panel

--- a/components/sc2/sc2-section-header.js
+++ b/components/sc2/sc2-section-header.js
@@ -1,0 +1,30 @@
+import { Box, Heading } from '@chakra-ui/react'
+import { PROTOSS_CYAN, PROTOSS_CYAN_RGB } from '../../lib/site-theme-context'
+
+// Angular tab-style section heading (SC2 research screen header tab):
+// uppercase mono, cyan glow, clipped top-left corner, luminous underline.
+const Sc2SectionHeader = ({ children, as = 'h2', ...rest }) => (
+  <Box mt={6} mb={4} {...rest}>
+    <Heading
+      as={as}
+      display="inline-block"
+      fontFamily="mono"
+      fontSize="13px"
+      fontWeight={700}
+      textTransform="uppercase"
+      letterSpacing="0.18em"
+      color="#c0e8ff"
+      textShadow={`0 0 10px rgba(${PROTOSS_CYAN_RGB}, 0.5)`}
+      bg={`rgba(${PROTOSS_CYAN_RGB}, 0.08)`}
+      border={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.3)`}
+      borderBottom={`2px solid ${PROTOSS_CYAN}`}
+      px={4}
+      py={1.5}
+      clipPath="polygon(10px 0, 100% 0, 100% 100%, 0 100%, 0 10px)"
+    >
+      ▸ {children}
+    </Heading>
+  </Box>
+)
+
+export default Sc2SectionHeader

--- a/components/work.js
+++ b/components/work.js
@@ -1,6 +1,7 @@
 import NextLink from 'next/link'
 import { Heading, Box, Image, Link, Badge } from '@chakra-ui/react'
 import { ChevronRightIcon } from '@chakra-ui/icons'
+import { PROTOSS_CYAN_RGB } from '../lib/site-theme-context'
 
 export const Title = ({ children }) => (
   <Box>
@@ -11,18 +12,39 @@ export const Title = ({ children }) => (
       {' '}
       <ChevronRightIcon />{' '}
     </span>
-    <Heading display="inline-block" as="h3" fontSize={20} mb={4}>
+    <Heading
+      display="inline-block"
+      as="h3"
+      fontSize={20}
+      mb={4}
+      textShadow={`0 0 12px rgba(${PROTOSS_CYAN_RGB}, 0.4)`}
+    >
       {children}
     </Heading>
   </Box>
 )
 
 export const WorkImage = ({ src, alt }) => (
-  <Image borderRadius="lg" w="full" src={src} alt={alt} mb={4} />
+  <Image
+    borderRadius="4px"
+    border={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.25)`}
+    w="full"
+    src={src}
+    alt={alt}
+    mb={4}
+  />
 )
 
+// SC2 command tag — cyan console badge for tech/platform meta
 export const Meta = ({ children }) => (
-  <Badge colorScheme="green" mr={2}>
+  <Badge
+    fontFamily="mono"
+    bg={`rgba(${PROTOSS_CYAN_RGB}, 0.14)`}
+    color="#7dd8ff"
+    border={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.4)`}
+    borderRadius="2px"
+    mr={2}
+  >
     {children}
   </Badge>
 )

--- a/lib/site-theme-context.js
+++ b/lib/site-theme-context.js
@@ -1,10 +1,4 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  useEffect,
-  useCallback
-} from 'react'
+import { createContext, useContext, useState, useCallback } from 'react'
 
 // Color palettes for each game theme
 export const PALETTES = {
@@ -45,14 +39,13 @@ const SiteThemeContext = createContext({ theme: 'sc2', toggleTheme: () => {} })
 
 export function SiteThemeProvider({ children }) {
   // FFIX theme temporarily hidden (#7) — SC2 is the sole active theme.
-  // To re-enable: default back to 'ffix', restore the localStorage read
-  // below, and re-add <GameThemeToggle /> in components/navbar.js.
+  // To re-enable: default back to 'ffix', re-add <GameThemeToggle /> in
+  // components/navbar.js, and restore the localStorage preference read:
+  //   useEffect(() => {
+  //     const stored = localStorage.getItem('siteTheme')
+  //     if (stored === 'sc2') setTheme('sc2')
+  //   }, [])
   const [theme, setTheme] = useState('sc2')
-
-  useEffect(() => {
-    // const stored = localStorage.getItem('siteTheme')
-    // if (stored === 'sc2') setTheme('sc2')
-  }, [])
 
   const toggleTheme = useCallback(() => {
     setTheme(prev => {

--- a/lib/site-theme-context.js
+++ b/lib/site-theme-context.js
@@ -41,14 +41,17 @@ export const KHALA_GOLD = '#f0c040'
 export const KHALA_GOLD_RGB = '240, 192, 64'
 export const FFIX_GOLD_RGB = '224, 192, 0'
 
-const SiteThemeContext = createContext({ theme: 'ffix', toggleTheme: () => {} })
+const SiteThemeContext = createContext({ theme: 'sc2', toggleTheme: () => {} })
 
 export function SiteThemeProvider({ children }) {
-  const [theme, setTheme] = useState('ffix')
+  // FFIX theme temporarily hidden (#7) — SC2 is the sole active theme.
+  // To re-enable: default back to 'ffix', restore the localStorage read
+  // below, and re-add <GameThemeToggle /> in components/navbar.js.
+  const [theme, setTheme] = useState('sc2')
 
   useEffect(() => {
-    const stored = localStorage.getItem('siteTheme')
-    if (stored === 'sc2') setTheme('sc2')
+    // const stored = localStorage.getItem('siteTheme')
+    // if (stored === 'sc2') setTheme('sc2')
   }, [])
 
   const toggleTheme = useCallback(() => {

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -4,7 +4,8 @@ import { mode } from '@chakra-ui/theme-tools'
 const styles = {
   global: props => ({
     body: {
-      bg: mode('#f5f5f7', '#0a0a0b')(props),
+      // Deep-space navy — SC2 command console base (#7)
+      bg: mode('#e8eef5', '#05080f')(props),
       // Smooth color mode transitions
       transition: 'background-color 0.2s ease'
     }
@@ -14,16 +15,18 @@ const styles = {
 const components = {
   Heading: {
     variants: {
-      // 2025 editorial style: uppercase + left blue border instead of underline
+      // SC2 console style: uppercase mono tab with psionic cyan accent (#7)
       'section-title': {
+        fontFamily: "'Share Tech Mono', monospace",
         fontSize: 13,
         fontWeight: 700,
         textTransform: 'uppercase',
-        letterSpacing: '0.1em',
+        letterSpacing: '0.15em',
         paddingLeft: 3,
         borderLeftWidth: '3px',
         borderLeftStyle: 'solid',
-        borderLeftColor: '#3B82F6',
+        borderLeftColor: '#00ddff',
+        textShadow: '0 0 10px rgba(0,221,255,0.35)',
         marginTop: 6,
         marginBottom: 4,
         color: 'inherit',
@@ -33,20 +36,20 @@ const components = {
   },
   Link: {
     baseStyle: props => ({
-      color: mode('#2563EB', '#60A5FA')(props),
+      color: mode('#0891b2', '#7dd8ff')(props),
       textUnderlineOffset: 3
     })
   }
 }
 
 const fonts = {
-  heading: "'Cinzel', Georgia, serif",          // FFIX-style: classical elegant fantasy
+  heading: "'Cinzel', Georgia, serif", // FFIX-style: classical elegant fantasy
   body: "'DM Sans', system-ui, sans-serif",
   mono: "'Share Tech Mono', 'Courier New', monospace" // retro-tech mono for FFIX panels
 }
 
 const colors = {
-  grassTeal: '#3B82F6'
+  grassTeal: '#00bbdd' // protoss cyan — nav/accent token (#7)
 }
 
 const config = {

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -43,7 +43,7 @@ const components = {
 }
 
 const fonts = {
-  heading: "'Cinzel', Georgia, serif", // FFIX-style: classical elegant fantasy
+  heading: "'Cinzel', Georgia, serif", // kept for compatibility while FFIX is dormant (#7)
   body: "'DM Sans', system-ui, sans-serif",
   mono: "'Share Tech Mono', 'Courier New', monospace" // retro-tech mono for FFIX panels
 }

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,24 +1,36 @@
 import NextLink from 'next/link'
-import {
-  Box,
-  Heading,
-  Text,
-  Container,
-  Divider,
-  Button
-} from '@chakra-ui/react'
+import { Box, Heading, Text, Container } from '@chakra-ui/react'
+import Sc2Panel from '../components/sc2/sc2-panel'
+import Sc2Button from '../components/sc2/sc2-button'
+import { PROTOSS_CYAN_RGB, PALETTES } from '../lib/site-theme-context'
 
+// SC2 console error screen — signal lost
 const NotFound = () => {
   return (
-    <Container>
-      <Heading as="h1">Not found</Heading>
-      <Text>The page you&apos;re looking for was not found.</Text>
-      <Divider my={6} />
-      <Box my={6} align="center">
-        <Button as={NextLink} href="/" colorScheme="teal">
-          Return to home
-        </Button>
-      </Box>
+    <Container pt={10}>
+      <Sc2Panel title="signal lost" meta="ERR-404">
+        <Heading
+          as="h1"
+          fontFamily="mono"
+          fontSize="2xl"
+          textTransform="uppercase"
+          letterSpacing="0.12em"
+          color="#c0e8ff"
+          textShadow={`0 0 16px rgba(${PROTOSS_CYAN_RGB}, 0.6)`}
+          mb={3}
+        >
+          404 — Sector Not Found
+        </Heading>
+        <Text fontFamily="mono" fontSize="sm" color={PALETTES.sc2.muted} mb={6}>
+          The coordinates you warped to do not exist in this sector. The Khala
+          holds no memory of this place.
+        </Text>
+        <Box textAlign="center" my={4}>
+          <Sc2Button as={NextLink} href="/" variant="gold">
+            Return to Nexus
+          </Sc2Button>
+        </Box>
+      </Sc2Panel>
     </Container>
   )
 }

--- a/pages/posts.js
+++ b/pages/posts.js
@@ -1,18 +1,21 @@
 import Parser from 'rss-parser'
-import { Box, Container, Heading, Text, Link, Flex } from '@chakra-ui/react'
+import { Box, Container, Text, Link, Flex } from '@chakra-ui/react'
 import Layout from '../components/layouts/article'
 import Section from '../components/section'
+import Sc2SectionHeader from '../components/sc2/sc2-section-header'
+import { PROTOSS_CYAN, PALETTES } from '../lib/site-theme-context'
 
-const PANEL_BG = 'rgba(8, 14, 40, 0.97)'
-const GOLD = '#c8a800'
-const CREAM = '#f0e6a0'
-const MUTED = '#9890a0'
+// SC2 console tokens (#7)
+const PANEL_BG = PALETTES.sc2.panelBg
+const ACCENT = PROTOSS_CYAN
+const TEXT = PALETTES.sc2.text
+const MUTED = PALETTES.sc2.muted
 
 // Format ISO date → "Mar 2026"
 const formatDate = iso =>
   new Date(iso).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
 
-// Single FFIX-styled post row
+// Single console-styled transmission row
 const PostRow = ({ title, link, pubDate, contentSnippet }, i) => (
   <Box
     key={link}
@@ -27,19 +30,25 @@ const PostRow = ({ title, link, pubDate, contentSnippet }, i) => (
       gap={3}
       p={3}
       bg={PANEL_BG}
-      border={`1px solid ${GOLD}33`}
+      border={`1px solid ${ACCENT}33`}
       borderRadius="sm"
       fontFamily="monospace"
-      _hover={{ borderColor: `${GOLD}88`, bg: 'rgba(200,168,0,0.04)' }}
+      _hover={{ borderColor: `${ACCENT}88`, bg: 'rgba(0,187,221,0.05)' }}
       transition="all 0.15s"
       align="flex-start"
     >
       {/* Index */}
-      <Text fontSize="10px" color={GOLD} mt="2px" flexShrink={0} w="18px">
+      <Text fontSize="10px" color={ACCENT} mt="2px" flexShrink={0} w="18px">
         {String(i + 1).padStart(2, '0')}
       </Text>
       <Box flex={1} minW={0}>
-        <Text fontSize="sm" color={CREAM} fontWeight={600} lineHeight={1.3} mb={1}>
+        <Text
+          fontSize="sm"
+          color={TEXT}
+          fontWeight={600}
+          lineHeight={1.3}
+          mb={1}
+        >
           {title}
         </Text>
         {contentSnippet && (
@@ -58,31 +67,37 @@ const PostRow = ({ title, link, pubDate, contentSnippet }, i) => (
 const Posts = ({ posts, error }) => (
   <Layout title="Posts">
     <Container>
-      <Heading as="h1" fontSize={20} mb={4}>
+      <Sc2SectionHeader as="h1" mt={0}>
         Posts
-      </Heading>
+      </Sc2SectionHeader>
 
-      {/* FFIX panel header */}
+      {/* Console panel header */}
       <Box
         bg={PANEL_BG}
-        border={`2px solid ${GOLD}`}
+        border={`2px solid ${ACCENT}`}
         borderRadius="sm"
-        boxShadow={`0 0 0 3px rgba(8,14,40,0.9), 0 0 0 5px ${GOLD}33`}
+        boxShadow={`0 0 0 3px rgba(4,12,28,0.9), 0 0 0 5px ${ACCENT}33, inset 0 0 24px rgba(0,221,255,0.05)`}
         overflow="hidden"
         mb={6}
       >
         <Flex
-          px={4} py={2}
-          bg="rgba(200,168,0,0.06)"
-          borderBottom={`1px solid ${GOLD}44`}
+          px={4}
+          py={2}
+          bg="rgba(0,187,221,0.06)"
+          borderBottom={`1px solid ${ACCENT}44`}
           justify="space-between"
           align="center"
         >
-          <Text fontFamily="monospace" fontSize="10px" color={GOLD} letterSpacing="0.15em">
-            ◆ MOGNET ARCHIVES — coderhorizon.com
+          <Text
+            fontFamily="monospace"
+            fontSize="10px"
+            color={ACCENT}
+            letterSpacing="0.15em"
+          >
+            ▸ KHALAI ARCHIVE — coderhorizon.com
           </Text>
           <Text fontFamily="monospace" fontSize="10px" color={MUTED}>
-            {posts.length} dispatches
+            {posts.length} transmissions
           </Text>
         </Flex>
 
@@ -94,7 +109,7 @@ const Posts = ({ posts, error }) => (
           )}
           {!error && posts.length === 0 && (
             <Text fontFamily="monospace" fontSize="sm" color={MUTED}>
-              ◇ No dispatches yet — check back soon
+              ◇ No transmissions yet — check back soon
             </Text>
           )}
           {posts.map((post, i) => PostRow(post, i))}
@@ -108,11 +123,11 @@ const Posts = ({ posts, error }) => (
             isExternal
             fontFamily="monospace"
             fontSize="xs"
-            color={GOLD}
+            color={ACCENT}
             letterSpacing="0.1em"
-            _hover={{ color: CREAM }}
+            _hover={{ color: TEXT }}
           >
-            ◆ Subscribe on Substack →
+            ▸ Subscribe on Substack →
           </Link>
         </Flex>
       </Section>
@@ -124,12 +139,14 @@ export async function getStaticProps() {
   try {
     const parser = new Parser({ timeout: 8000 })
     const feed = await parser.parseURL('https://coderhorizon.com/feed')
-    const posts = (feed.items || []).map(({ title, link, pubDate, contentSnippet }) => ({
-      title: title || '',
-      link: link || '',
-      pubDate: pubDate || null,
-      contentSnippet: contentSnippet ? contentSnippet.slice(0, 200) : '',
-    }))
+    const posts = (feed.items || []).map(
+      ({ title, link, pubDate, contentSnippet }) => ({
+        title: title || '',
+        link: link || '',
+        pubDate: pubDate || null,
+        contentSnippet: contentSnippet ? contentSnippet.slice(0, 200) : ''
+      })
+    )
     return { props: { posts, error: false }, revalidate: 3600 } // refresh hourly
   } catch {
     return { props: { posts: [], error: true }, revalidate: 300 }

--- a/pages/wallpapers/index.js
+++ b/pages/wallpapers/index.js
@@ -1,8 +1,9 @@
 import NextLink from 'next/link'
-import { Box, Container, Heading, SimpleGrid, Link } from '@chakra-ui/react'
+import { Box, Container, SimpleGrid, Link } from '@chakra-ui/react'
 import Layout from '../../components/layouts/article'
 import Section from '../../components/section'
 import { WorkGridItem } from '../../components/grid-item'
+import Sc2SectionHeader from '../../components/sc2/sc2-section-header'
 
 import thumbCherryBlossoms from '../../public/images/wallpapers/cherry-blossoms/ls-13.jpg'
 import thumbMachiya from '../../public/images/wallpapers/machiya/ls-03.jpg'
@@ -10,9 +11,9 @@ import thumbMachiya from '../../public/images/wallpapers/machiya/ls-03.jpg'
 const Wallpapers = () => (
   <Layout title="Wallpaper Packs">
     <Container>
-      <Heading as="h3" fontSize={20} mb={4}>
+      <Sc2SectionHeader as="h1" mt={0}>
         Wallpaper Packs
-      </Heading>
+      </Sc2SectionHeader>
 
       <Box my={4}>
         The wallpaper packs offer a selection of carefully curated images

--- a/pages/works.js
+++ b/pages/works.js
@@ -1,7 +1,8 @@
-import { Container, Heading, SimpleGrid, Divider } from '@chakra-ui/react'
+import { Container, SimpleGrid, Divider } from '@chakra-ui/react'
 import Layout from '../components/layouts/article'
 import Section from '../components/section'
 import { WorkGridItem } from '../components/grid-item'
+import Sc2SectionHeader from '../components/sc2/sc2-section-header'
 
 import thumbTTM from '../public/images/works/ttm.png'
 import thumbTTMW from '../public/images/works/ttm_w.png'
@@ -12,9 +13,9 @@ import thumbShopware6 from '../public/images/works/shopware6.png'
 const Works = () => (
   <Layout title="Works">
     <Container>
-      <Heading as="h1" fontSize={20} mb={4}>
+      <Sc2SectionHeader as="h1" mt={0}>
         Works
-      </Heading>
+      </Sc2SectionHeader>
 
       <SimpleGrid columns={[1, 1, 2]} gap={6}>
         <Section>
@@ -24,48 +25,57 @@ const Works = () => (
         </Section>
 
         <Section>
-          <WorkGridItem id="ttm-whitelabel" title="TikTok Management Whitelabel" thumbnail={thumbTTMW}>
-            The Whitelable system for TikTok Management.
-            You want to be a TikTok Agency? This is the right choice.
+          <WorkGridItem
+            id="ttm-whitelabel"
+            title="TikTok Management Whitelabel"
+            thumbnail={thumbTTMW}
+          >
+            The Whitelable system for TikTok Management. You want to be a TikTok
+            Agency? This is the right choice.
           </WorkGridItem>
         </Section>
-
       </SimpleGrid>
 
       <Section delay={0.2}>
-        <Divider my={6} />
+        <Divider my={6} borderColor="rgba(0,221,255,0.2)" />
 
-        <Heading as="h2" fontSize={20} mb={4}>
-          Contribute
-        </Heading>
+        <Sc2SectionHeader>Contribute</Sc2SectionHeader>
       </Section>
 
       <SimpleGrid columns={[1, 1, 2]} gap={6}>
         <Section delay={0.3}>
-          <WorkGridItem id="shopware6" thumbnail={thumbShopware6} title="Shopware 6">
-            Shopware 6 is an open headless commerce platform powered by Symfony 7 and Vue.js 3.
+          <WorkGridItem
+            id="shopware6"
+            thumbnail={thumbShopware6}
+            title="Shopware 6"
+          >
+            Shopware 6 is an open headless commerce platform powered by Symfony
+            7 and Vue.js 3.
           </WorkGridItem>
         </Section>
         <Section delay={0.3}>
           <WorkGridItem id="laravue" thumbnail={thumbLaravue} title="Laravue">
-            Laravue is a beautiful dashboard combination of Laravel, Vue.js and the UI toolkit Element a.
+            Laravue is a beautiful dashboard combination of Laravel, Vue.js and
+            the UI toolkit Element a.
           </WorkGridItem>
         </Section>
       </SimpleGrid>
 
       <Section delay={0.4}>
-        <Divider my={6} />
+        <Divider my={6} borderColor="rgba(0,221,255,0.2)" />
 
-        <Heading as="h2" fontSize={20} mb={4}>
-          Old works
-        </Heading>
+        <Sc2SectionHeader>Old works</Sc2SectionHeader>
       </Section>
 
       <SimpleGrid columns={[1, 1, 2]} gap={6}>
         <Section delay={0.5}>
-          <WorkGridItem id="vtv_giaitri" thumbnail={thumbVtve} title="VTV GiaiTri">
-            VTV Entertainment is an application that provides exclusive entertainment
-            content from Vietnam Television Station.
+          <WorkGridItem
+            id="vtv_giaitri"
+            thumbnail={thumbVtve}
+            title="VTV GiaiTri"
+          >
+            VTV Entertainment is an application that provides exclusive
+            entertainment content from Vietnam Television Station.
           </WorkGridItem>
         </Section>
       </SimpleGrid>


### PR DESCRIPTION
## Summary
Restyles the whole site as a StarCraft II command-console UI and locks SC2 as the sole active theme. FFIX is hidden, not deleted — dormant with documented re-enable steps.

Closes #7

## Changes
**New primitives — `components/sc2/`**
- `sc2-panel.js` — console panel: navy body, luminous double border, optional header bar, hover-revealed corner brackets
- `sc2-button.js` — beveled clip-path button (cyan/gold/green variants), inset WCAG-compliant focus ring
- `sc2-section-header.js` — angular tab heading, uppercase mono + cyan glow

**Applied sitewide**
- Theme locked to `sc2` (default flipped; FFIX toggle + color-mode toggle removed from navbar; re-enable notes in `site-theme-context.js`)
- Navbar → command-console top bar (cyan tab links, glow active state, focus-visible outlines)
- Works/Wallpapers grids → command-card slots (corner brackets + psionic glow on hover, thumbnails brighten)
- Posts → "Khalai Archive" transmission log (recolored from FFIX gold, uses `PALETTES.sc2` tokens)
- Work detail pages → cyan command-tag badges, framed images
- 404 → "Signal Lost" console panel + gold "Return to Nexus" CTA
- Footer → Pylon beacon crystal ("En Taro Adun")
- Global: deep-space navy body, cyan section-title variant + links
- FFIX gold leak fixed in `ffix-tetra-card` / `ffix-world-map` (hardcoded constants outside the palette system)

## Verification
- [x] `next lint` 0 errors; `next build` compiles, all routes
- [x] Independent code review: 0 blockers; 1 major (gold leak) + 4 minors (focus visibility, dead code, menu states) — all fixed in `1ae2901`
- [x] Keyboard focus visible on all restyled interactive elements
- [x] FFIX dormant — no FFIX visuals render anywhere

## Deferred (follow-ups)
- Palette-token DRY sweep across remaining files (reviewer minor; next PR adopts tokens for all touched files per approved Protoss spec)
- Protoss full look-and-feel: `plans/260704-1510-protoss-look-and-feel/SPEC.md`
