### PR TITLE
feat: Protoss race look and feel — gold ornate UI, psionic chrome, terminology

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -1,5 +1,6 @@
 import { Box, Text, Flex } from '@chakra-ui/react'
 import { motion } from 'framer-motion'
+import { KHALA_GOLD } from '../lib/site-theme-context'
 
 const Footer = () => {
   return (
@@ -24,7 +25,7 @@ const Footer = () => {
               cy="14"
               r="13"
               fill="none"
-              stroke="#f0c040"
+              stroke={KHALA_GOLD}
               strokeWidth="0.6"
               opacity="0.4"
             />

--- a/components/footer.js
+++ b/components/footer.js
@@ -24,7 +24,7 @@ const Footer = () => {
               cy="14"
               r="13"
               fill="none"
-              stroke="#00ddff"
+              stroke="#f0c040"
               strokeWidth="0.6"
               opacity="0.4"
             />

--- a/components/grid-item.js
+++ b/components/grid-item.js
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import { Box, Text, LinkBox, LinkOverlay } from '@chakra-ui/react'
 import { Global } from '@emotion/react'
 import { Sc2CornerBrackets } from './sc2/sc2-panel'
-import { PROTOSS_CYAN_RGB } from '../lib/site-theme-context'
+import { PROTOSS_CYAN_RGB, KHALA_GOLD_RGB } from '../lib/site-theme-context'
 
 // SC2 command-card slot styling shared by both grid variants:
 // dark navy slot, luminous border, hover = corner brackets + psionic glow
@@ -11,14 +11,14 @@ const cardSlotProps = {
   role: 'group',
   position: 'relative',
   display: 'block',
-  bg: 'rgba(4, 12, 28, 0.85)',
-  border: `1px solid rgba(${PROTOSS_CYAN_RGB}, 0.25)`,
+  bg: 'rgba(10, 8, 24, 0.85)',
+  border: `1px solid rgba(${KHALA_GOLD_RGB}, 0.35)`,
   borderRadius: '4px',
   p: 3,
   cursor: 'pointer',
   transition: 'all 0.2s',
   _hover: {
-    borderColor: `rgba(${PROTOSS_CYAN_RGB}, 0.7)`,
+    borderColor: `rgba(${KHALA_GOLD_RGB}, 0.85)`,
     boxShadow: `0 0 18px rgba(${PROTOSS_CYAN_RGB}, 0.25), inset 0 0 14px rgba(${PROTOSS_CYAN_RGB}, 0.06)`
   }
 }

--- a/components/layouts/main.js
+++ b/components/layouts/main.js
@@ -114,7 +114,7 @@ const Main = ({ children, router }) => {
         <title>Tony Tin Nguyen — Building products that scale.</title>
       </Head>
 
-      <ProtossGlobal />
+      {theme === 'sc2' && <ProtossGlobal />}
       {theme === 'sc2' && <LazyPsionicBackground />}
 
       <NavBar path={router.asPath} />

--- a/components/layouts/main.js
+++ b/components/layouts/main.js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import dynamic from 'next/dynamic'
 import NavBar from '../navbar'
+import ProtossGlobal from '../sc2/protoss-global'
 import { Box, Container } from '@chakra-ui/react'
 import Footer from '../footer'
 import VoxelDogLoader from '../voxel-dog-loader'
@@ -113,6 +114,7 @@ const Main = ({ children, router }) => {
         <title>Tony Tin Nguyen — Building products that scale.</title>
       </Head>
 
+      <ProtossGlobal />
       {theme === 'sc2' && <LazyPsionicBackground />}
 
       <NavBar path={router.asPath} />

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -15,7 +15,11 @@ import {
   IconButton
 } from '@chakra-ui/react'
 import { HamburgerIcon } from '@chakra-ui/icons'
-import { PROTOSS_CYAN, PROTOSS_CYAN_RGB } from '../lib/site-theme-context'
+import {
+  PROTOSS_CYAN,
+  PROTOSS_CYAN_RGB,
+  KHALA_GOLD_RGB
+} from '../lib/site-theme-context'
 // GameThemeToggle + ThemeToggleButton removed while FFIX is hidden (#7) —
 // site is locked to the SC2 dark console look. Components kept for re-enable.
 
@@ -70,8 +74,8 @@ const Navbar = props => {
       as="nav"
       w="100%"
       bg="rgba(4, 10, 24, 0.85)"
-      borderBottom={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.25)`}
-      boxShadow={`0 0 18px rgba(${PROTOSS_CYAN_RGB}, 0.12)`}
+      borderBottom={`1px solid rgba(${KHALA_GOLD_RGB}, 0.35)`}
+      boxShadow={`0 0 18px rgba(${KHALA_GOLD_RGB}, 0.10)`}
       css={{ backdropFilter: 'blur(10px)' }}
       zIndex={2}
       {...props}
@@ -114,14 +118,14 @@ const Navbar = props => {
                 as={IconButton}
                 icon={<HamburgerIcon />}
                 variant="outline"
-                borderColor={`rgba(${PROTOSS_CYAN_RGB}, 0.45)`}
+                borderColor={`rgba(${KHALA_GOLD_RGB}, 0.5)`}
                 color="#c0e8ff"
                 _hover={{ bg: `rgba(${PROTOSS_CYAN_RGB}, 0.12)` }}
                 aria-label="Options"
               />
               <MenuList
                 bg="rgba(4, 12, 28, 0.97)"
-                borderColor={`rgba(${PROTOSS_CYAN_RGB}, 0.35)`}
+                borderColor={`rgba(${KHALA_GOLD_RGB}, 0.45)`}
                 fontFamily="mono"
                 fontSize="sm"
               >

--- a/components/sc2/protoss-global.js
+++ b/components/sc2/protoss-global.js
@@ -1,4 +1,14 @@
 import { Global } from '@emotion/react'
+import {
+  PROTOSS_BRONZE,
+  PROTOSS_DEEP_GOLD,
+  PROTOSS_TEAL_RGB,
+  PROTOSS_CYAN_RGB,
+  KHALA_GOLD_RGB
+} from '../../lib/site-theme-context'
+
+// One-off decorative constant — scrollbar rail; darker than any panel token
+const TRACK_BG = '#05040c'
 
 // Protoss contextual chrome (#9): psionic scrollbar, selection color,
 // energy-seam + crystal-gem keyframes. All animation is disabled under
@@ -8,18 +18,18 @@ const ProtossGlobal = () => (
     styles={`
       /* Psionic scrollbar — bronze rail, energy thumb */
       ::-webkit-scrollbar { width: 10px; height: 10px; }
-      ::-webkit-scrollbar-track { background: #05040c; }
+      ::-webkit-scrollbar-track { background: ${TRACK_BG}; }
       ::-webkit-scrollbar-thumb {
-        background: linear-gradient(180deg, #8a6d2f, rgba(0, 187, 221, 0.55));
-        border: 1px solid rgba(240, 192, 64, 0.35);
+        background: linear-gradient(180deg, ${PROTOSS_BRONZE}, rgba(${PROTOSS_TEAL_RGB}, 0.55));
+        border: 1px solid rgba(${KHALA_GOLD_RGB}, 0.35);
         border-radius: 2px;
       }
       ::-webkit-scrollbar-thumb:hover {
-        background: linear-gradient(180deg, #c89a30, rgba(0, 221, 255, 0.7));
+        background: linear-gradient(180deg, ${PROTOSS_DEEP_GOLD}, rgba(${PROTOSS_CYAN_RGB}, 0.7));
       }
-      * { scrollbar-width: thin; scrollbar-color: #8a6d2f #05040c; }
+      * { scrollbar-width: thin; scrollbar-color: ${PROTOSS_BRONZE} ${TRACK_BG}; }
 
-      ::selection { background: rgba(0, 221, 255, 0.35); color: #eafcff; }
+      ::selection { background: rgba(${PROTOSS_CYAN_RGB}, 0.35); color: #eafcff; }
 
       /* Energy seam — cyan pulse travelling along a panel edge */
       @keyframes protoss-seam {
@@ -28,7 +38,7 @@ const ProtossGlobal = () => (
       }
       .protoss-seam {
         background-image: linear-gradient(
-          90deg, transparent, rgba(0, 221, 255, 0.9), transparent
+          90deg, transparent, rgba(${PROTOSS_CYAN_RGB}, 0.9), transparent
         );
         background-size: 45% 100%;
         background-repeat: no-repeat;

--- a/components/sc2/protoss-global.js
+++ b/components/sc2/protoss-global.js
@@ -1,0 +1,52 @@
+import { Global } from '@emotion/react'
+
+// Protoss contextual chrome (#9): psionic scrollbar, selection color,
+// energy-seam + crystal-gem keyframes. All animation is disabled under
+// prefers-reduced-motion.
+const ProtossGlobal = () => (
+  <Global
+    styles={`
+      /* Psionic scrollbar — bronze rail, energy thumb */
+      ::-webkit-scrollbar { width: 10px; height: 10px; }
+      ::-webkit-scrollbar-track { background: #05040c; }
+      ::-webkit-scrollbar-thumb {
+        background: linear-gradient(180deg, #8a6d2f, rgba(0, 187, 221, 0.55));
+        border: 1px solid rgba(240, 192, 64, 0.35);
+        border-radius: 2px;
+      }
+      ::-webkit-scrollbar-thumb:hover {
+        background: linear-gradient(180deg, #c89a30, rgba(0, 221, 255, 0.7));
+      }
+      * { scrollbar-width: thin; scrollbar-color: #8a6d2f #05040c; }
+
+      ::selection { background: rgba(0, 221, 255, 0.35); color: #eafcff; }
+
+      /* Energy seam — cyan pulse travelling along a panel edge */
+      @keyframes protoss-seam {
+        0% { background-position: -60% 0; }
+        100% { background-position: 160% 0; }
+      }
+      .protoss-seam {
+        background-image: linear-gradient(
+          90deg, transparent, rgba(0, 221, 255, 0.9), transparent
+        );
+        background-size: 45% 100%;
+        background-repeat: no-repeat;
+        animation: protoss-seam 3.2s linear infinite;
+      }
+
+      /* Crystal gem core pulse */
+      @keyframes protoss-gem-pulse {
+        0%, 100% { opacity: 0.35; }
+        50% { opacity: 0.95; }
+      }
+      .protoss-gem-core { animation: protoss-gem-pulse 2.4s ease-in-out infinite; }
+
+      @media (prefers-reduced-motion: reduce) {
+        .protoss-seam, .protoss-gem-core { animation: none; }
+      }
+    `}
+  />
+)
+
+export default ProtossGlobal

--- a/components/sc2/protoss-ornament.js
+++ b/components/sc2/protoss-ornament.js
@@ -52,7 +52,7 @@ export const ProtossCrystalGem = ({ size = 10, ...pos }) => (
     <svg width={size} height={size * 1.4} viewBox="0 0 10 14" fill="none">
       <polygon
         points="5,0 10,4 8,13 2,13 0,4"
-        fill="#1a1030"
+        fill="#1a1030" /* one-off gem body tint */
         stroke={PROTOSS_DEEP_GOLD}
         strokeWidth="1"
       />

--- a/components/sc2/protoss-ornament.js
+++ b/components/sc2/protoss-ornament.js
@@ -1,0 +1,76 @@
+import { Box } from '@chakra-ui/react'
+import {
+  KHALA_GOLD,
+  PROTOSS_CYAN,
+  PROTOSS_DEEP_GOLD
+} from '../../lib/site-theme-context'
+
+// Corner transforms: mirror the top-left wing into each corner
+const CORNERS = {
+  tl: { top: '-3px', left: '-3px', transform: 'none' },
+  tr: { top: '-3px', right: '-3px', transform: 'scaleX(-1)' },
+  bl: { bottom: '-3px', left: '-3px', transform: 'scaleY(-1)' },
+  br: { bottom: '-3px', right: '-3px', transform: 'scale(-1,-1)' }
+}
+
+// Ornate gold corner wing — Protoss frame flourish. Purely decorative.
+export const ProtossCornerWing = ({ corner = 'tl', size = 26 }) => {
+  const { transform, ...pos } = CORNERS[corner] || CORNERS.tl
+  return (
+    <Box
+      aria-hidden
+      position="absolute"
+      pointerEvents="none"
+      zIndex={1}
+      style={{ transform }}
+      {...pos}
+    >
+      <svg width={size} height={size} viewBox="0 0 26 26" fill="none">
+        {/* outer gold wing */}
+        <path
+          d="M1 25 L1 9 L9 1 L25 1"
+          stroke={KHALA_GOLD}
+          strokeWidth="2.5"
+          strokeLinecap="square"
+        />
+        {/* inner psionic energy trace */}
+        <path
+          d="M4 18 L4 10 L10 4 L18 4"
+          stroke={PROTOSS_CYAN}
+          strokeWidth="1"
+          opacity="0.65"
+        />
+      </svg>
+    </Box>
+  )
+}
+
+// Small khaydarin crystal gem with pulsing cyan core (pulse defined in
+// protoss-global.js, disabled under prefers-reduced-motion).
+export const ProtossCrystalGem = ({ size = 10, ...pos }) => (
+  <Box aria-hidden position="absolute" pointerEvents="none" zIndex={1} {...pos}>
+    <svg width={size} height={size * 1.4} viewBox="0 0 10 14" fill="none">
+      <polygon
+        points="5,0 10,4 8,13 2,13 0,4"
+        fill="#1a1030"
+        stroke={PROTOSS_DEEP_GOLD}
+        strokeWidth="1"
+      />
+      <polygon
+        className="protoss-gem-core"
+        points="5,2 8,4.5 7,11 3,11 2,4.5"
+        fill={PROTOSS_CYAN}
+        opacity="0.6"
+      />
+    </svg>
+  </Box>
+)
+
+// Convenience: all four corner wings for a panel
+export const ProtossFrameCorners = ({ size }) => (
+  <>
+    {Object.keys(CORNERS).map(c => (
+      <ProtossCornerWing key={c} corner={c} size={size} />
+    ))}
+  </>
+)

--- a/components/sc2/sc2-button.js
+++ b/components/sc2/sc2-button.js
@@ -35,7 +35,7 @@ const Sc2Button = ({ variant = 'cyan', children, ...rest }) => {
       border="1px solid"
       borderColor={`rgba(${v.rgb}, 0.55)`}
       clipPath="polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px)"
-      boxShadow={`inset 0 0 12px rgba(${v.rgb}, 0.18)`}
+      boxShadow={`inset 0 0 12px rgba(${v.rgb}, 0.18), inset 0 1px 0 rgba(${KHALA_GOLD_RGB}, 0.35)`}
       _hover={{
         bg: `rgba(${v.rgb}, 0.24)`,
         color: v.hoverColor,

--- a/components/sc2/sc2-panel.js
+++ b/components/sc2/sc2-panel.js
@@ -2,8 +2,12 @@ import { Box, Flex, Text } from '@chakra-ui/react'
 import {
   PALETTES,
   PROTOSS_CYAN,
-  PROTOSS_CYAN_RGB
+  PROTOSS_CYAN_RGB,
+  KHALA_GOLD_RGB,
+  PROTOSS_PANEL_BG,
+  PROTOSS_PANEL_RGB
 } from '../../lib/site-theme-context'
+import { ProtossFrameCorners } from './protoss-ornament'
 
 const sc2 = PALETTES.sc2
 
@@ -75,19 +79,31 @@ const Sc2Panel = ({
   <Box
     position="relative"
     role={brackets ? 'group' : undefined}
-    bg={sc2.panelBg}
-    border={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.35)`}
+    bg={PROTOSS_PANEL_BG}
+    border={`1px solid rgba(${KHALA_GOLD_RGB}, 0.55)`}
     borderRadius="4px"
-    boxShadow={`inset 0 0 24px rgba(${PROTOSS_CYAN_RGB}, 0.07), 0 0 0 3px rgba(4, 12, 28, 0.8), 0 0 0 4px rgba(${PROTOSS_CYAN_RGB}, 0.15)`}
+    boxShadow={`inset 0 0 24px rgba(${PROTOSS_CYAN_RGB}, 0.06), 0 0 0 3px rgba(${PROTOSS_PANEL_RGB}, 0.8), 0 0 0 4px rgba(${KHALA_GOLD_RGB}, 0.25)`}
     {...rest}
   >
+    {/* Protoss gold frame ornaments + travelling energy seam (#9) */}
+    <ProtossFrameCorners />
+    <Box
+      aria-hidden
+      className="protoss-seam"
+      position="absolute"
+      top="-1px"
+      left="8%"
+      right="8%"
+      h="2px"
+      pointerEvents="none"
+    />
     {brackets && <Sc2CornerBrackets hoverReveal />}
     {title && (
       <Flex
         px={4}
         py={2}
-        bg={sc2.headerBg}
-        borderBottom={`1px solid ${sc2.headerBorder}`}
+        bg={`rgba(${KHALA_GOLD_RGB}, 0.07)`}
+        borderBottom={`1px solid rgba(${KHALA_GOLD_RGB}, 0.35)`}
         justify="space-between"
         align="center"
       >

--- a/components/sc2/sc2-panel.js
+++ b/components/sc2/sc2-panel.js
@@ -7,7 +7,7 @@ import {
   PROTOSS_PANEL_BG,
   PROTOSS_PANEL_RGB
 } from '../../lib/site-theme-context'
-import { ProtossFrameCorners } from './protoss-ornament'
+import { ProtossFrameCorners, ProtossCrystalGem } from './protoss-ornament'
 
 const sc2 = PALETTES.sc2
 
@@ -87,6 +87,9 @@ const Sc2Panel = ({
   >
     {/* Protoss gold frame ornaments + travelling energy seam (#9) */}
     <ProtossFrameCorners />
+    {/* Khaydarin gems at the lower frame joints */}
+    <ProtossCrystalGem bottom="-7px" left="24px" />
+    <ProtossCrystalGem bottom="-7px" right="24px" />
     <Box
       aria-hidden
       className="protoss-seam"

--- a/components/sc2/sc2-section-header.js
+++ b/components/sc2/sc2-section-header.js
@@ -1,5 +1,9 @@
 import { Box, Heading } from '@chakra-ui/react'
-import { PROTOSS_CYAN, PROTOSS_CYAN_RGB } from '../../lib/site-theme-context'
+import {
+  PROTOSS_CYAN_RGB,
+  KHALA_GOLD,
+  KHALA_GOLD_RGB
+} from '../../lib/site-theme-context'
 
 // Angular tab-style section heading (SC2 research screen header tab):
 // uppercase mono, cyan glow, clipped top-left corner, luminous underline.
@@ -15,9 +19,9 @@ const Sc2SectionHeader = ({ children, as = 'h2', ...rest }) => (
       letterSpacing="0.18em"
       color="#c0e8ff"
       textShadow={`0 0 10px rgba(${PROTOSS_CYAN_RGB}, 0.5)`}
-      bg={`rgba(${PROTOSS_CYAN_RGB}, 0.08)`}
-      border={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.3)`}
-      borderBottom={`2px solid ${PROTOSS_CYAN}`}
+      bg={`rgba(${KHALA_GOLD_RGB}, 0.08)`}
+      border={`1px solid rgba(${KHALA_GOLD_RGB}, 0.45)`}
+      borderBottom={`2px solid ${KHALA_GOLD}`}
       px={4}
       py={1.5}
       clipPath="polygon(10px 0, 100% 0, 100% 100%, 0 100%, 0 10px)"

--- a/components/work.js
+++ b/components/work.js
@@ -1,7 +1,7 @@
 import NextLink from 'next/link'
 import { Heading, Box, Image, Link, Badge } from '@chakra-ui/react'
 import { ChevronRightIcon } from '@chakra-ui/icons'
-import { PROTOSS_CYAN_RGB } from '../lib/site-theme-context'
+import { PROTOSS_CYAN_RGB, KHALA_GOLD_RGB } from '../lib/site-theme-context'
 
 export const Title = ({ children }) => (
   <Box>
@@ -27,7 +27,7 @@ export const Title = ({ children }) => (
 export const WorkImage = ({ src, alt }) => (
   <Image
     borderRadius="4px"
-    border={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.25)`}
+    border={`1px solid rgba(${KHALA_GOLD_RGB}, 0.35)`}
     w="full"
     src={src}
     alt={alt}
@@ -39,9 +39,9 @@ export const WorkImage = ({ src, alt }) => (
 export const Meta = ({ children }) => (
   <Badge
     fontFamily="mono"
-    bg={`rgba(${PROTOSS_CYAN_RGB}, 0.14)`}
-    color="#7dd8ff"
-    border={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.4)`}
+    bg={`rgba(${KHALA_GOLD_RGB}, 0.14)`}
+    color="#ffe8b0"
+    border={`1px solid rgba(${KHALA_GOLD_RGB}, 0.5)`}
     borderRadius="2px"
     mr={2}
   >

--- a/lib/protoss-terminology.js
+++ b/lib/protoss-terminology.js
@@ -1,0 +1,15 @@
+// Protoss terminology map (#9) — single source for themed UI labels.
+// Nav links intentionally keep short forms (Works/Blog) for usability;
+// these long forms appear as page/section headings only.
+// Spec: plans/260704-1510-protoss-look-and-feel/SPEC.md §3
+export const PROTOSS_LABELS = {
+  works: 'Chronicles of the Khala',
+  posts: 'Khala Transmissions',
+  career: 'Path of the Templar',
+  featured: 'Relics',
+  location: 'Star Chart',
+  onTheWeb: 'Psionic Links',
+  contribute: 'Offerings to the Conclave',
+  oldWorks: 'Ancient Archives',
+  viewPortfolio: 'Access Chronicles'
+}

--- a/lib/site-theme-context.js
+++ b/lib/site-theme-context.js
@@ -34,6 +34,11 @@ export const PROTOSS_TEAL_RGB = '0, 187, 221'
 export const KHALA_GOLD = '#f0c040'
 export const KHALA_GOLD_RGB = '240, 192, 64'
 export const FFIX_GOLD_RGB = '224, 192, 0'
+// Protoss canon frame tokens (#9): gold/bronze chrome, purple-navy bodies
+export const PROTOSS_BRONZE = '#8a6d2f'
+export const PROTOSS_DEEP_GOLD = '#c89a30'
+export const PROTOSS_PANEL_BG = 'rgba(10, 8, 24, 0.97)'
+export const PROTOSS_PANEL_RGB = '10, 8, 24'
 
 const SiteThemeContext = createContext({ theme: 'sc2', toggleTheme: () => {} })
 

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -1,5 +1,10 @@
 import { extendTheme } from '@chakra-ui/react'
 import { mode } from '@chakra-ui/theme-tools'
+import {
+  PROTOSS_CYAN,
+  PROTOSS_CYAN_RGB,
+  KHALA_GOLD_RGB
+} from './site-theme-context'
 
 const styles = {
   global: props => ({
@@ -25,8 +30,8 @@ const components = {
         paddingLeft: 3,
         borderLeftWidth: '3px',
         borderLeftStyle: 'solid',
-        borderLeftColor: '#00ddff',
-        textShadow: '0 0 10px rgba(0,221,255,0.35)',
+        borderLeftColor: PROTOSS_CYAN,
+        textShadow: `0 0 10px rgba(${PROTOSS_CYAN_RGB}, 0.35)`,
         marginTop: 6,
         marginBottom: 4,
         color: 'inherit',
@@ -45,11 +50,11 @@ const components = {
     baseStyle: {
       bg: 'rgba(10, 8, 24, 0.97)',
       color: '#c0e8ff',
-      border: '1px solid rgba(240,192,64,0.5)',
+      border: `1px solid rgba(${KHALA_GOLD_RGB}, 0.5)`,
       borderRadius: '2px',
       fontFamily: "'Share Tech Mono', monospace",
       fontSize: 'xs',
-      boxShadow: '0 0 12px rgba(0,221,255,0.25)'
+      boxShadow: `0 0 12px rgba(${PROTOSS_CYAN_RGB}, 0.25)`
     }
   },
   Input: {
@@ -57,12 +62,12 @@ const components = {
       outline: {
         field: {
           bg: 'rgba(10, 8, 24, 0.6)',
-          borderColor: 'rgba(240,192,64,0.4)',
+          borderColor: `rgba(${KHALA_GOLD_RGB}, 0.4)`,
           borderRadius: '2px',
-          _hover: { borderColor: 'rgba(240,192,64,0.7)' },
+          _hover: { borderColor: `rgba(${KHALA_GOLD_RGB}, 0.7)` },
           _focusVisible: {
-            borderColor: '#00ddff',
-            boxShadow: '0 0 0 1px #00ddff, 0 0 12px rgba(0,221,255,0.3)'
+            borderColor: PROTOSS_CYAN,
+            boxShadow: `0 0 0 1px ${PROTOSS_CYAN}, 0 0 12px rgba(${PROTOSS_CYAN_RGB}, 0.3)`
           }
         }
       }
@@ -72,12 +77,12 @@ const components = {
     variants: {
       outline: {
         bg: 'rgba(10, 8, 24, 0.6)',
-        borderColor: 'rgba(240,192,64,0.4)',
+        borderColor: `rgba(${KHALA_GOLD_RGB}, 0.4)`,
         borderRadius: '2px',
-        _hover: { borderColor: 'rgba(240,192,64,0.7)' },
+        _hover: { borderColor: `rgba(${KHALA_GOLD_RGB}, 0.7)` },
         _focusVisible: {
-          borderColor: '#00ddff',
-          boxShadow: '0 0 0 1px #00ddff, 0 0 12px rgba(0,221,255,0.3)'
+          borderColor: PROTOSS_CYAN,
+          boxShadow: `0 0 0 1px ${PROTOSS_CYAN}, 0 0 12px rgba(${PROTOSS_CYAN_RGB}, 0.3)`
         }
       }
     }

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -39,11 +39,53 @@ const components = {
       color: mode('#0891b2', '#7dd8ff')(props),
       textUnderlineOffset: 3
     })
+  },
+  // Protoss contextual elements (#9): gold-framed, cyan psionic focus
+  Tooltip: {
+    baseStyle: {
+      bg: 'rgba(10, 8, 24, 0.97)',
+      color: '#c0e8ff',
+      border: '1px solid rgba(240,192,64,0.5)',
+      borderRadius: '2px',
+      fontFamily: "'Share Tech Mono', monospace",
+      fontSize: 'xs',
+      boxShadow: '0 0 12px rgba(0,221,255,0.25)'
+    }
+  },
+  Input: {
+    variants: {
+      outline: {
+        field: {
+          bg: 'rgba(10, 8, 24, 0.6)',
+          borderColor: 'rgba(240,192,64,0.4)',
+          borderRadius: '2px',
+          _hover: { borderColor: 'rgba(240,192,64,0.7)' },
+          _focusVisible: {
+            borderColor: '#00ddff',
+            boxShadow: '0 0 0 1px #00ddff, 0 0 12px rgba(0,221,255,0.3)'
+          }
+        }
+      }
+    }
+  },
+  Textarea: {
+    variants: {
+      outline: {
+        bg: 'rgba(10, 8, 24, 0.6)',
+        borderColor: 'rgba(240,192,64,0.4)',
+        borderRadius: '2px',
+        _hover: { borderColor: 'rgba(240,192,64,0.7)' },
+        _focusVisible: {
+          borderColor: '#00ddff',
+          boxShadow: '0 0 0 1px #00ddff, 0 0 12px rgba(0,221,255,0.3)'
+        }
+      }
+    }
   }
 }
 
 const fonts = {
-  heading: "'Cinzel', Georgia, serif", // kept for compatibility while FFIX is dormant (#7)
+  heading: "'Orbitron', 'Share Tech Mono', sans-serif", // Protoss geometric face (#9)
   body: "'DM Sans', system-ui, sans-serif",
   mono: "'Share Tech Mono', 'Courier New', monospace" // retro-tech mono for FFIX panels
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -9,15 +9,19 @@ export default class Document extends NextDocument {
         <Head>
           {/* Preconnect + preload Space Grotesk — faster than @import in CSS */}
           <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="anonymous"
+          />
           <link
             rel="preload"
             as="style"
-            href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=DM+Sans:wght@400;500;700&family=Share+Tech+Mono&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700&family=DM+Sans:wght@400;500;700&family=Share+Tech+Mono&display=swap"
           />
           <link
             rel="stylesheet"
-            href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=DM+Sans:wght@400;500;700&family=Share+Tech+Mono&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700&family=DM+Sans:wght@400;500;700&family=Share+Tech+Mono&display=swap"
           />
         </Head>
         <body>

--- a/pages/index.js
+++ b/pages/index.js
@@ -25,6 +25,7 @@ import FfixTetraCards from '../components/ffix-tetra-card'
 import FfixEncounter from '../components/ffix-encounter'
 import FfixWorldMap from '../components/ffix-world-map'
 import ProtossWarpIn from '../components/protoss-warp-in'
+import { PROTOSS_LABELS } from '../lib/protoss-terminology'
 import {
   useSiteTheme,
   PROTOSS_CYAN,
@@ -301,7 +302,7 @@ const Home = () => {
                   colorScheme="blue"
                   size="sm"
                 >
-                  View portfolio
+                  {PROTOSS_LABELS.viewPortfolio}
                 </Button>
               </Box>
             </Section>
@@ -337,7 +338,7 @@ const Home = () => {
             {/* TETRA MASTER CARDS */}
             <Section delay={0.25}>
               <Heading as="h3" variant="section-title">
-                Featured
+                {PROTOSS_LABELS.featured}
               </Heading>
               <FfixTetraCards />
             </Section>
@@ -346,7 +347,7 @@ const Home = () => {
             <Box display={{ base: 'block', lg: 'none' }}>
               <Section delay={0.2}>
                 <Heading as="h3" variant="section-title">
-                  Career
+                  {PROTOSS_LABELS.career}
                 </Heading>
                 {CareerPanel}
               </Section>
@@ -355,7 +356,7 @@ const Home = () => {
             {/* WORLD MAP */}
             <Section delay={0.3}>
               <Heading as="h3" variant="section-title">
-                Location
+                {PROTOSS_LABELS.location}
               </Heading>
               <FfixWorldMap />
             </Section>
@@ -363,7 +364,7 @@ const Home = () => {
             {/* SOCIAL LINKS */}
             <Section delay={0.35}>
               <Heading as="h3" variant="section-title">
-                On the web
+                {PROTOSS_LABELS.onTheWeb}
               </Heading>
               <Flex gap={3} wrap="wrap" mt={2}>
                 {socialLinks.map(({ icon, label, href }) => (
@@ -423,7 +424,7 @@ const Home = () => {
           >
             <Section delay={0.2}>
               <Heading as="h3" variant="section-title">
-                Career
+                {PROTOSS_LABELS.career}
               </Heading>
               {CareerPanel}
             </Section>

--- a/pages/posts.js
+++ b/pages/posts.js
@@ -4,6 +4,7 @@ import Layout from '../components/layouts/article'
 import Section from '../components/section'
 import Sc2SectionHeader from '../components/sc2/sc2-section-header'
 import { PROTOSS_CYAN, PALETTES } from '../lib/site-theme-context'
+import { PROTOSS_LABELS } from '../lib/protoss-terminology'
 
 // SC2 console tokens (#7)
 const PANEL_BG = PALETTES.sc2.panelBg
@@ -68,7 +69,7 @@ const Posts = ({ posts, error }) => (
   <Layout title="Posts">
     <Container>
       <Sc2SectionHeader as="h1" mt={0}>
-        Posts
+        {PROTOSS_LABELS.posts}
       </Sc2SectionHeader>
 
       {/* Console panel header */}

--- a/pages/works.js
+++ b/pages/works.js
@@ -3,6 +3,7 @@ import Layout from '../components/layouts/article'
 import Section from '../components/section'
 import { WorkGridItem } from '../components/grid-item'
 import Sc2SectionHeader from '../components/sc2/sc2-section-header'
+import { PROTOSS_LABELS } from '../lib/protoss-terminology'
 
 import thumbTTM from '../public/images/works/ttm.png'
 import thumbTTMW from '../public/images/works/ttm_w.png'
@@ -14,7 +15,7 @@ const Works = () => (
   <Layout title="Works">
     <Container>
       <Sc2SectionHeader as="h1" mt={0}>
-        Works
+        {PROTOSS_LABELS.works}
       </Sc2SectionHeader>
 
       <SimpleGrid columns={[1, 1, 2]} gap={6}>
@@ -39,7 +40,7 @@ const Works = () => (
       <Section delay={0.2}>
         <Divider my={6} borderColor="rgba(0,221,255,0.2)" />
 
-        <Sc2SectionHeader>Contribute</Sc2SectionHeader>
+        <Sc2SectionHeader>{PROTOSS_LABELS.contribute}</Sc2SectionHeader>
       </Section>
 
       <SimpleGrid columns={[1, 1, 2]} gap={6}>
@@ -64,7 +65,7 @@ const Works = () => (
       <Section delay={0.4}>
         <Divider my={6} borderColor="rgba(0,221,255,0.2)" />
 
-        <Sc2SectionHeader>Old works</Sc2SectionHeader>
+        <Sc2SectionHeader>{PROTOSS_LABELS.oldWorks}</Sc2SectionHeader>
       </Section>
 
       <SimpleGrid columns={[1, 1, 2]} gap={6}>


### PR DESCRIPTION
## Summary
Evolves the SC2 console UI (#8) into **full Protoss canon**: gold/bronze ornate frames with khaydarin crystal accents on purple-navy, cyan reserved for psionic energy. Covers window UI, contextual chrome, shape/typography language, and Protoss terminology.

Closes #9 — spec: `plans/260704-1510-protoss-look-and-feel/SPEC.md` (approved)

## Changes
**Tokens & typography**
- New tokens: `PROTOSS_BRONZE`, `PROTOSS_DEEP_GOLD`, `PROTOSS_PANEL_BG` (purple-navy)
- Heading font Cinzel → **Orbitron** (geometric alien face, existing `_document.js` preload pattern)
- Chakra `Tooltip`/`Input`/`Textarea`: gold frames, cyan psionic focus rings

**Ornamentation (new)**
- `protoss-ornament.js` — SVG gold corner wings + pulsing khaydarin crystal gems (aria-hidden, pointer-events none)
- `protoss-global.js` — psionic scrollbar, `::selection`, energy-seam + gem keyframes; all animation off under `prefers-reduced-motion`; SC2-gated in layout

**Primitives & shell**
- `sc2-panel` — gold ornate frame, purple-navy body, corner wings, crystal gems at lower joints, travelling cyan energy seam
- `sc2-button` — gold bevel highlight; `sc2-section-header` — gold tab frame, cyan text
- Navbar/cards/badges/footer crystal → gold chrome (cyan kept as energy accents)

**Terminology** — `lib/protoss-terminology.js` single-source map: Works→*Chronicles of the Khala*, Posts→*Khala Transmissions*, Career→*Path of the Templar*, Featured→*Relics*, Location→*Star Chart*, On the web→*Psionic Links*, Contribute→*Offerings to the Conclave*, Old works→*Ancient Archives*. Nav keeps short labels; URLs unchanged.

## Verification
- [x] `next lint` 0 errors; `next build` compiles all routes; no new deps
- [x] Independent review: REQUEST CHANGES → all findings fixed (1 major: inline-hex spec violation tokenized; 5 minors: global-style tokens, footer token, dead exports mounted/used, ProtossGlobal theme-gated)
- [x] Reviewer verified: SSR-safe, compositor-friendly animations only, AA contrast, no Orbitron mobile overflow, reduced-motion coverage complete
- [x] FFIX dormant + re-enable parity preserved
