### PR TITLE
fix: pylon base rings share one material, phase-offset pulse invisible

### DIFF
--- a/components/protoss-pylon.js
+++ b/components/protoss-pylon.js
@@ -65,6 +65,9 @@ function createPylonCrystal(scene) {
 
   // Second ring (higher)
   const ring2 = ring.clone()
+  // clone() shares the material by reference — give ring2 its own so the
+  // phase-offset opacity pulse in the render loop is actually visible (#6)
+  ring2.material = ring.material.clone()
   ring2.position.y = 0.3
   ring2.scale.set(0.7, 0.7, 0.7)
   group.add(ring2)


### PR DESCRIPTION
One-line fix per #6: `ring2.material = ring.material.clone()` after the mesh clone, so the intended `Math.sin(t * 2.5)` vs `Math.sin(t * 2.5 + 1)` opacity offset between the two base rings actually renders.

- Root cause + fix specified in #6 (found during PR #5 review)
- Disposal safe: the `scene.traverse` cleanup from #5 disposes per-mesh materials; after the clone there is no shared instance
- `next lint` 0 errors, `next build` ✓

Closes #6