### PR TITLE
chore: pin packageManager to yarn@1.22.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "keywords": [],
   "author": "Tony Tin Nguyen",
   "license": "MIT",
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.1",


### PR DESCRIPTION
Fixes `yarn` commands failing in this repo with a corepack error.

**Root cause:** yarn 1 walks up the directory tree for a `packageManager` field and was hitting a pnpm pin in a parent-directory `package.json` (outside this repo, intentionally left untouched — it belongs to a separate home-directory setup).

**Fix:** pin `yarn@1.22.22` in this repo's `package.json` — stops the walk, scoped to this project.

**Verified:** `yarn lint` now completes (`Done in 3.19s`); previously errored before running anything.