### PR TITLE
style: format lib/model.js with prettier

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1,8 +1,8 @@
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
 import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js'
 
-const draco = new DRACOLoader();
-draco.setDecoderConfig({ type: 'js' });
+const draco = new DRACOLoader()
+draco.setDecoderConfig({ type: 'js' })
 draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/')
 
 export function loadGLTFModel(
@@ -13,7 +13,7 @@ export function loadGLTFModel(
   const { receiveShadow, castShadow } = options
   return new Promise((resolve, reject) => {
     const loader = new GLTFLoader()
-    loader.setDRACOLoader( draco );
+    loader.setDRACOLoader(draco)
 
     loader.load(
       glbPath,


### PR DESCRIPTION
Format-only diff (semicolons/spacing) — picked up by a `prettier --write lib/*.js` run during #9; identical to what `yarn prettier` produces. No behavior change.