### PR TITLE
chore: ignore .omc/ tooling dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 .env
 .gstack/
 .env*.local
+.omc/
+public/.omc/


### PR DESCRIPTION
Adds `.omc/` and `public/.omc/` (local oh-my-claudecode tooling state) to .gitignore — removes them from git status noise.