### PR TITLE
feat: SC2 minimap world map, LotV capsule menu, Protoss shield background

### DIFF
--- a/components/ffix-world-map.js
+++ b/components/ffix-world-map.js
@@ -1,13 +1,20 @@
 import { Box, Text, Flex } from '@chakra-ui/react'
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
+import {
+  PROTOSS_CYAN,
+  PROTOSS_CYAN_RGB,
+  KHALA_GOLD,
+  KHALA_GOLD_RGB,
+  PROTOSS_PANEL_BG,
+  PALETTES
+} from '../lib/site-theme-context'
 
-const PANEL_BG = 'rgba(8, 14, 40, 0.97)'
-const GOLD = '#00bbdd' // SC2 accent while FFIX is hidden (#7); was '#c8a800'
-const LAND = '#1a3a2a'
-const OCEAN = PANEL_BG
+// SC2 tactical minimap (#16): dark terrain, cyan grid, unit blips,
+// camera viewport rect, scan sweep. Base marker at Danang, Vietnam.
+const LAND = '#0f2438' // dark tactical terrain
+const LAND_EDGE = `rgba(${PROTOSS_CYAN_RGB}, 0.35)`
 
 // Simplified world map paths in a 700×320 viewBox (Mercator-ish)
-// Danang, Vietnam: 108.2°E 16.1°N → x≈641, y≈164 — marked with pulsing dot
 const CONTINENTS = [
   // North America
   'M 68 58 L 138 48 L 168 68 L 178 98 L 162 158 L 128 172 L 88 164 L 62 138 L 54 108 Z',
@@ -33,111 +40,171 @@ const CONTINENTS = [
   'M 280 64 L 294 60 L 298 80 L 285 84 Z'
 ]
 
-// Danang coordinates in the same projection
+// Base (player) at Danang; fixed ally/enemy blips for tactical flavor
 const DANANG = { x: 550, y: 168 }
+const ALLY_BLIPS = [
+  { x: 300, y: 80 }, // Europe
+  { x: 590, y: 95 }, // Japan
+  { x: 130, y: 110 }, // North America
+  { x: 575, y: 265 } // Australia
+]
+const ENEMY_BLIPS = [
+  { x: 330, y: 180 }, // Africa
+  { x: 480, y: 60 } // North Asia
+]
 
-const FfixWorldMap = () => (
-  <Box
-    bg={PANEL_BG}
-    border={`2px solid ${GOLD}`}
-    borderRadius="sm"
-    boxShadow={`0 0 0 3px rgba(8,14,40,0.9), 0 0 0 5px ${GOLD}33`}
-    overflow="hidden"
-    fontFamily="monospace"
-  >
-    {/* Header */}
-    <Flex
-      px={3}
-      py={2}
-      bg="rgba(0,187,221,0.06)"
-      borderBottom={`1px solid ${GOLD}44`}
-      justify="space-between"
-      align="center"
+const FfixWorldMap = () => {
+  const reduceMotion = useReducedMotion()
+  return (
+    <Box
+      bg={PROTOSS_PANEL_BG}
+      border={`2px solid rgba(${KHALA_GOLD_RGB}, 0.6)`}
+      borderRadius="sm"
+      boxShadow={`0 0 0 3px rgba(10,8,24,0.9), 0 0 0 5px rgba(${KHALA_GOLD_RGB}, 0.2)`}
+      overflow="hidden"
+      fontFamily="monospace"
     >
-      <Text fontSize="10px" color={GOLD} letterSpacing="0.15em">
-        ◆ WORLD MAP
-      </Text>
-      <Flex align="center" gap={1}>
-        <Box w={2} h={2} borderRadius="full" bg="green.400" />
-        <Text fontSize="9px" color="#9890a0">
-          DANANG, VIETNAM
-        </Text>
-      </Flex>
-    </Flex>
-
-    {/* SVG map */}
-    <Box bg={OCEAN} position="relative">
-      <svg
-        viewBox="0 0 700 320"
-        xmlns="http://www.w3.org/2000/svg"
-        style={{ display: 'block', width: '100%' }}
+      {/* Command header */}
+      <Flex
+        px={3}
+        py={2}
+        bg={`rgba(${KHALA_GOLD_RGB}, 0.07)`}
+        borderBottom={`1px solid rgba(${KHALA_GOLD_RGB}, 0.35)`}
+        justify="space-between"
+        align="center"
       >
-        {/* Ocean grid lines */}
-        {[...Array(8)].map((_, i) => (
-          <line
-            key={`h${i}`}
-            x1="0"
-            y1={i * 40}
-            x2="700"
-            y2={i * 40}
-            stroke="#ffffff06"
-            strokeWidth="0.5"
-          />
-        ))}
-        {[...Array(14)].map((_, i) => (
-          <line
-            key={`v${i}`}
-            x1={i * 50}
-            y1="0"
-            x2={i * 50}
-            y2="320"
-            stroke="#ffffff06"
-            strokeWidth="0.5"
-          />
-        ))}
+        <Text fontSize="10px" color={PROTOSS_CYAN} letterSpacing="0.15em">
+          ▸ TACTICAL MAP — SECTOR: EARTH
+        </Text>
+        <Flex align="center" gap={1}>
+          <Box w={2} h={2} borderRadius="full" bg="green.400" />
+          <Text fontSize="9px" color={PALETTES.sc2.muted}>
+            BASE: DANANG · 16.1°N 108.2°E
+          </Text>
+        </Flex>
+      </Flex>
 
-        {/* Continents */}
-        {CONTINENTS.map((d, i) => (
-          <path
-            key={i}
-            d={d}
-            fill={LAND}
-            stroke="#2a5a3a"
-            strokeWidth="0.8"
-            opacity={0.9}
-          />
-        ))}
-
-        {/* Danang — outer pulse ring */}
-        <motion.circle
-          cx={DANANG.x}
-          cy={DANANG.y}
-          r="12"
-          fill="none"
-          stroke="#00cc55"
-          strokeWidth="1"
-          initial={{ r: 6, opacity: 0.8 }}
-          animate={{ r: 16, opacity: 0 }}
-          transition={{ repeat: Infinity, duration: 2, ease: 'easeOut' }}
-        />
-        {/* Danang — dot */}
-        <circle cx={DANANG.x} cy={DANANG.y} r="4" fill="#00ff66" />
-        <circle cx={DANANG.x} cy={DANANG.y} r="2" fill="white" />
-
-        {/* Danang — label */}
-        <text
-          x={DANANG.x + 8}
-          y={DANANG.y - 6}
-          fontSize="9"
-          fill={GOLD}
-          fontFamily="monospace"
-          letterSpacing="0.5"
+      {/* Minimap */}
+      <Box position="relative">
+        <svg
+          viewBox="0 0 700 320"
+          xmlns="http://www.w3.org/2000/svg"
+          style={{ display: 'block', width: '100%' }}
         >
-          DANANG
-        </text>
-      </svg>
+          {/* Tactical grid */}
+          {[...Array(16)].map((_, i) => (
+            <line
+              key={`h${i}`}
+              x1="0"
+              y1={i * 20}
+              x2="700"
+              y2={i * 20}
+              stroke={`rgba(${PROTOSS_CYAN_RGB}, 0.05)`}
+              strokeWidth="0.5"
+            />
+          ))}
+          {[...Array(28)].map((_, i) => (
+            <line
+              key={`v${i}`}
+              x1={i * 25}
+              y1="0"
+              x2={i * 25}
+              y2="320"
+              stroke={`rgba(${PROTOSS_CYAN_RGB}, 0.05)`}
+              strokeWidth="0.5"
+            />
+          ))}
+
+          {/* Terrain */}
+          {CONTINENTS.map((d, i) => (
+            <path
+              key={i}
+              d={d}
+              fill={LAND}
+              stroke={LAND_EDGE}
+              strokeWidth="0.8"
+              opacity={0.95}
+            />
+          ))}
+
+          {/* Camera viewport rect over the base region (minimap idiom) */}
+          <rect
+            x={505}
+            y={130}
+            width={95}
+            height={78}
+            fill="none"
+            stroke="rgba(232, 248, 255, 0.75)"
+            strokeWidth="1.2"
+          />
+
+          {/* Ally blips (psionic cyan) */}
+          {ALLY_BLIPS.map((b, i) => (
+            <circle
+              key={`a${i}`}
+              cx={b.x}
+              cy={b.y}
+              r="2.4"
+              fill={PROTOSS_CYAN}
+              opacity="0.85"
+            />
+          ))}
+          {/* Enemy blips */}
+          {ENEMY_BLIPS.map((b, i) => (
+            <circle
+              key={`e${i}`}
+              cx={b.x}
+              cy={b.y}
+              r="2.4"
+              fill="#ff5544"
+              opacity="0.85"
+            />
+          ))}
+
+          {/* Base — outer pulse ring */}
+          {!reduceMotion && (
+            <motion.circle
+              cx={DANANG.x}
+              cy={DANANG.y}
+              r="12"
+              fill="none"
+              stroke="#00cc55"
+              strokeWidth="1"
+              initial={{ r: 6, opacity: 0.8 }}
+              animate={{ r: 16, opacity: 0 }}
+              transition={{ repeat: Infinity, duration: 2, ease: 'easeOut' }}
+            />
+          )}
+          {/* Base — nexus dot */}
+          <circle cx={DANANG.x} cy={DANANG.y} r="4" fill="#00ff66" />
+          <circle cx={DANANG.x} cy={DANANG.y} r="2" fill="white" />
+          <text
+            x={DANANG.x + 8}
+            y={DANANG.y - 6}
+            fontSize="9"
+            fill={KHALA_GOLD}
+            fontFamily="monospace"
+            letterSpacing="0.5"
+          >
+            NEXUS: DANANG
+          </text>
+
+          {/* Scan sweep — slow vertical pass */}
+          {!reduceMotion && (
+            <motion.line
+              x1="0"
+              x2="700"
+              stroke={`rgba(${PROTOSS_CYAN_RGB}, 0.35)`}
+              strokeWidth="1.5"
+              initial={{ y1: 0, y2: 0, opacity: 0.5 }}
+              animate={{ y1: 320, y2: 320, opacity: 0.15 }}
+              transition={{ repeat: Infinity, duration: 6, ease: 'linear' }}
+            />
+          )}
+        </svg>
+      </Box>
     </Box>
-  </Box>
-)
+  )
+}
 
 export default FfixWorldMap

--- a/components/ffix-world-map.js
+++ b/components/ffix-world-map.js
@@ -166,7 +166,7 @@ const FfixWorldMap = () => {
             <motion.circle
               cx={DANANG.x}
               cy={DANANG.y}
-              r="12"
+              r="6" // matches initial — avoids SSR-to-hydration snap
               fill="none"
               stroke="#00cc55"
               strokeWidth="1"

--- a/components/layouts/main.js
+++ b/components/layouts/main.js
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import dynamic from 'next/dynamic'
 import NavBar from '../navbar'
 import ProtossGlobal from '../sc2/protoss-global'
+import ProtossShieldLayer from '../protoss-shield-layer'
 import { Box, Container } from '@chakra-ui/react'
 import Footer from '../footer'
 import VoxelDogLoader from '../voxel-dog-loader'
@@ -116,6 +117,7 @@ const Main = ({ children, router }) => {
 
       {theme === 'sc2' && <ProtossGlobal />}
       {theme === 'sc2' && <LazyPsionicBackground />}
+      {theme === 'sc2' && <ProtossShieldLayer />}
 
       <NavBar path={router.asPath} />
 

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -23,7 +23,8 @@ import {
 // GameThemeToggle + ThemeToggleButton removed while FFIX is hidden (#7) —
 // site is locked to the SC2 dark console look. Components kept for re-enable.
 
-// Console tab link (SC2 menu style): uppercase mono, cyan glow when active
+// LotV capsule menu button (#16): rounded capsule, thin blue border,
+// dark gradient fill; active = double-border glow (ref: LotV achievements UI)
 const LinkItem = ({ href, path, target, children, ...props }) => {
   const active = path === href
   return (
@@ -31,20 +32,33 @@ const LinkItem = ({ href, path, target, children, ...props }) => {
       as={NextLink}
       href={href}
       scroll={false}
-      px={3}
-      py={2}
+      px={4}
+      py={1.5}
       fontFamily="mono"
       fontSize="xs"
       fontWeight="bold"
       textTransform="uppercase"
       letterSpacing="0.12em"
+      borderRadius="6px"
+      border="1px solid"
+      borderColor={
+        active
+          ? `rgba(${PROTOSS_CYAN_RGB}, 0.9)`
+          : `rgba(${PROTOSS_CYAN_RGB}, 0.3)`
+      }
+      bg="linear-gradient(180deg, rgba(14, 24, 48, 0.9), rgba(5, 10, 24, 0.9))"
       color={active ? '#eafcff' : '#8fb8cc'}
-      bg={active ? `rgba(${PROTOSS_CYAN_RGB}, 0.14)` : undefined}
-      boxShadow={active ? `inset 0 -2px 0 ${PROTOSS_CYAN}` : undefined}
+      boxShadow={
+        active
+          ? `inset 0 0 0 1px rgba(${PROTOSS_CYAN_RGB}, 0.55), 0 0 12px rgba(${PROTOSS_CYAN_RGB}, 0.35)`
+          : 'none'
+      }
       textShadow={active ? `0 0 10px rgba(${PROTOSS_CYAN_RGB}, 0.7)` : 'none'}
       _hover={{
         textDecoration: 'none',
         color: '#c0e8ff',
+        borderColor: `rgba(${PROTOSS_CYAN_RGB}, 0.7)`,
+        boxShadow: `0 0 10px rgba(${PROTOSS_CYAN_RGB}, 0.25)`,
         textShadow: `0 0 8px rgba(${PROTOSS_CYAN_RGB}, 0.6)`
       }}
       _focusVisible={{

--- a/components/protoss-shield-layer.js
+++ b/components/protoss-shield-layer.js
@@ -1,0 +1,74 @@
+import { Box } from '@chakra-ui/react'
+import { PROTOSS_CYAN_RGB } from '../lib/site-theme-context'
+
+// Protoss plasma-shield background layer (#16): translucent cyan hexagonal
+// energy field with a slow shimmer and occasional expanding ripples.
+// Pure SVG/CSS (GPU-cheap); animations defined in protoss-global.js and
+// disabled under prefers-reduced-motion. Sits above the psionic canvas,
+// below all content.
+
+// Pointy-top hexagon tile, 28px wide — repeated via SVG <pattern>
+const HEX_PATH = 'M14 0 L28 8 L28 24 L14 32 L0 24 L0 8 Z'
+
+const ProtossShieldLayer = () => (
+  <Box
+    aria-hidden
+    position="fixed"
+    inset={0}
+    zIndex={-1}
+    pointerEvents="none"
+    overflow="hidden"
+  >
+    {/* Hexagonal energy lattice */}
+    <svg width="100%" height="100%" style={{ display: 'block' }}>
+      <defs>
+        <pattern
+          id="protoss-hex-lattice"
+          width="42"
+          height="48"
+          patternUnits="userSpaceOnUse"
+        >
+          <path
+            d={HEX_PATH}
+            transform="translate(7, 8)"
+            fill="none"
+            stroke={`rgba(${PROTOSS_CYAN_RGB}, 0.05)`}
+            strokeWidth="1"
+          />
+        </pattern>
+      </defs>
+      <rect
+        width="100%"
+        height="100%"
+        fill="url(#protoss-hex-lattice)"
+        className="protoss-shield-shimmer"
+      />
+    </svg>
+
+    {/* Expanding shield ripples — staggered, very low opacity */}
+    <Box
+      className="protoss-shield-ripple"
+      position="absolute"
+      top="30%"
+      left="20%"
+      w="40vmax"
+      h="40vmax"
+      borderRadius="full"
+      border={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.25)`}
+      boxShadow={`0 0 40px rgba(${PROTOSS_CYAN_RGB}, 0.08) inset`}
+    />
+    <Box
+      className="protoss-shield-ripple"
+      position="absolute"
+      top="55%"
+      left="65%"
+      w="34vmax"
+      h="34vmax"
+      borderRadius="full"
+      border={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.2)`}
+      style={{ animationDelay: '3.5s' }}
+    />
+  </Box>
+)
+
+export default ProtossShieldLayer

--- a/components/psionic-background.js
+++ b/components/psionic-background.js
@@ -152,7 +152,7 @@ const PsionicBackground = () => {
       style={{
         position: 'fixed',
         inset: 0,
-        zIndex: -1,
+        zIndex: -2, // below the shield layer (-1), explicit stacking
         pointerEvents: 'none'
       }}
     />

--- a/components/sc2/protoss-global.js
+++ b/components/sc2/protoss-global.js
@@ -52,8 +52,25 @@ const ProtossGlobal = () => (
       }
       .protoss-gem-core { animation: protoss-gem-pulse 2.4s ease-in-out infinite; }
 
+      /* Plasma-shield layer (#16): lattice shimmer + expanding ripples */
+      @keyframes protoss-shield-shimmer {
+        0%, 100% { opacity: 0.55; }
+        50% { opacity: 1; }
+      }
+      .protoss-shield-shimmer { animation: protoss-shield-shimmer 9s ease-in-out infinite; }
+      @keyframes protoss-shield-ripple {
+        0% { transform: scale(0.15); opacity: 0.45; }
+        100% { transform: scale(1.5); opacity: 0; }
+      }
+      .protoss-shield-ripple {
+        animation: protoss-shield-ripple 8s ease-out infinite;
+        will-change: transform, opacity;
+      }
+
       @media (prefers-reduced-motion: reduce) {
-        .protoss-seam, .protoss-gem-core { animation: none; }
+        .protoss-seam, .protoss-gem-core,
+        .protoss-shield-shimmer, .protoss-shield-ripple { animation: none; }
+        .protoss-shield-ripple { opacity: 0; }
       }
     `}
   />

--- a/components/sc2/protoss-global.js
+++ b/components/sc2/protoss-global.js
@@ -57,7 +57,10 @@ const ProtossGlobal = () => (
         0%, 100% { opacity: 0.55; }
         50% { opacity: 1; }
       }
-      .protoss-shield-shimmer { animation: protoss-shield-shimmer 9s ease-in-out infinite; }
+      .protoss-shield-shimmer {
+        animation: protoss-shield-shimmer 9s ease-in-out infinite;
+        will-change: opacity;
+      }
       @keyframes protoss-shield-ripple {
         0% { transform: scale(0.15); opacity: 0.45; }
         100% { transform: scale(1.5); opacity: 0; }


### PR DESCRIPTION
Closes #16 — three visual refinements on top of the Protoss canon UI (#9).

## Changes
- **World map → SC2 tactical minimap**: dark terrain + cyan grid, ally/enemy blips, camera viewport rect, NEXUS base marker at Danang (16.1°N 108.2°E), slow scan sweep — framer-motion, `useReducedMotion` gated
- **Navbar → LotV capsule buttons**: rounded capsules, thin blue border, dark gradient fill; active = double-border glow (ref: LotV achievements UI, interfaceingame.com)
- **Plasma-shield background layer** (new `protoss-shield-layer.js`): fixed hex-lattice SVG pattern with slow shimmer + expanding shield ripples; SC2-gated, pure SVG/CSS

## Verification
- `yarn lint` 0 errors, `yarn build` ✓, no new deps, tokens only
- Independent review: COMMENT, 0 blockers — 3 minors fixed (SSR pulse-ring hydration snap, explicit z-index stacking (-2 canvas / -1 shield), `will-change` on shimmer)
- Reviewer verified: reduced-motion coverage complete, focus-visible preserved, contrast >8.5:1, no CLS regression

Note: owner's two pasted reference images failed to upload; direction confirmed as canon interpretation + LotV URL reference.