### PR TITLE
feat: mission-briefing space backdrop, achievements panel, LotV tab menu

### DIFF
--- a/components/achievements-panel.js
+++ b/components/achievements-panel.js
@@ -58,7 +58,14 @@ const Medallion = ({ glow }) => (
     alignItems="center"
     justifyContent="center"
   >
-    <svg width="22" height="26" viewBox="0 0 10 14" fill="none">
+    <svg
+      width="22"
+      height="26"
+      viewBox="0 0 10 14"
+      fill="none"
+      aria-hidden="true"
+      focusable="false"
+    >
       <polygon
         points="5,0 10,4 8,13 2,13 0,4"
         fill="rgba(6, 10, 24, 0.9)"
@@ -79,7 +86,6 @@ const AchievementTile = ({ a }) => (
       borderRadius="4px"
       p={3}
       textAlign="center"
-      cursor="pointer"
       _hover={{
         borderColor: `${a.glow}88`,
         boxShadow: `0 0 16px ${a.glow}33`
@@ -97,7 +103,7 @@ const AchievementTile = ({ a }) => (
       >
         {a.name}
       </Text>
-      <Text fontSize="8px" color={`${a.glow}cc`} letterSpacing="0.12em" mb={1}>
+      <Text fontSize="9px" color={`${a.glow}cc`} letterSpacing="0.12em" mb={1}>
         {a.tier}
       </Text>
       {/* Gold point count (medal style) */}
@@ -124,7 +130,7 @@ const AchievementTile = ({ a }) => (
   </motion.div>
 )
 
-const FfixTetraCards = () => (
+const AchievementsPanel = () => (
   <Box
     bg={PROTOSS_PANEL_BG}
     border={`2px solid rgba(${KHALA_GOLD_RGB}, 0.6)`}
@@ -161,4 +167,4 @@ const FfixTetraCards = () => (
   </Box>
 )
 
-export default FfixTetraCards
+export default AchievementsPanel

--- a/components/ffix-tetra-card.js
+++ b/components/ffix-tetra-card.js
@@ -1,136 +1,124 @@
 import { Box, Text, Flex, SimpleGrid } from '@chakra-ui/react'
 import { motion } from 'framer-motion'
+import {
+  PROTOSS_CYAN,
+  PROTOSS_CYAN_RGB,
+  KHALA_GOLD,
+  KHALA_GOLD_RGB,
+  PROTOSS_PANEL_BG,
+  PALETTES
+} from '../lib/site-theme-context'
 
-const GOLD = '#00bbdd' // SC2 accent while FFIX is hidden (#7); was '#c8a800'
-const PANEL_BG = 'rgba(8, 14, 40, 0.97)'
+// Featured projects as an SC2 achievements panel (#19) — icon medallion,
+// tier, gold point count, cyan progress bar (ref: LotV achievements grid).
+const MUTED = PALETTES.sc2.muted
 
-// Project cards styled as FFIX Tetra Master cards
-// Values: A=Attack, P=Physical def, M=Magic def, X=Flexible
-const CARDS = [
+const ACHIEVEMENTS = [
   {
-    name: 'Ecomdy\nMedia',
-    type: 'LEGEND',
-    art: 'linear-gradient(135deg, #1a0a3a 0%, #3a1a6a 50%, #1a0a3a 100%)',
+    name: 'Ecomdy Media',
+    tier: 'LEGENDARY',
     glow: '#aa66ff',
-    A: 9,
-    P: 6,
-    M: 8,
-    X: 9
+    points: 3200,
+    progress: 90 // percent of campaign complete
   },
   {
-    name: 'Coder\nHorizon',
-    type: 'RARE',
-    art: 'linear-gradient(135deg, #0a1a3a 0%, #1a4a6a 50%, #0a1a3a 100%)',
+    name: 'Coder Horizon',
+    tier: 'EPIC',
     glow: '#44ccff',
-    A: 7,
-    P: 5,
-    M: 9,
-    X: 8
+    points: 2900,
+    progress: 80
   },
   {
-    name: 'GDG\nMien Trung',
-    type: 'RARE',
-    art: 'linear-gradient(135deg, #0a2a1a 0%, #1a5a2a 50%, #0a2a1a 100%)',
+    name: 'GDG Mien Trung',
+    tier: 'EPIC',
     glow: '#00cc55',
-    A: 6,
-    P: 7,
-    M: 7,
-    X: 9
+    points: 2900,
+    progress: 90
   },
   {
-    name: 'NFQ Asia\nShopware',
-    type: 'COMMON',
-    art: 'linear-gradient(135deg, #2a1a0a 0%, #5a3a1a 50%, #2a1a0a 100%)',
+    name: 'NFQ Asia · Shopware',
+    tier: 'RARE',
     glow: '#ffcc00',
-    A: 8,
-    P: 8,
-    M: 6,
-    X: 7
+    points: 2900,
+    progress: 70
   }
 ]
 
-// Single Tetra Master card
-const TetraCard = ({ card }) => (
-  <motion.div
-    whileHover={{ scale: 1.05, rotate: 1 }}
-    transition={{ duration: 0.2 }}
+// Square icon medallion with the project's glow color — LotV emblem style
+const Medallion = ({ glow }) => (
+  <Box
+    w="44px"
+    h="44px"
+    mx="auto"
+    borderRadius="6px"
+    border={`1.5px solid ${glow}aa`}
+    bg={`linear-gradient(160deg, ${glow}22, rgba(6, 10, 24, 0.95) 70%)`}
+    boxShadow={`0 0 12px ${glow}44, inset 0 0 10px ${glow}22`}
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
   >
-    <Box
-      bg={PANEL_BG}
-      border={`2px solid ${card.glow}66`}
-      borderRadius="sm"
-      overflow="hidden"
-      boxShadow={`0 0 0 1px rgba(8,14,40,0.9), 0 0 12px ${card.glow}22`}
-      fontFamily="monospace"
-      cursor="pointer"
-      position="relative"
-      _hover={{
-        boxShadow: `0 0 0 1px rgba(8,14,40,0.9), 0 0 20px ${card.glow}44`
-      }}
-      transition="box-shadow 0.2s"
-    >
-      {/* Card art area */}
-      <Box h="80px" background={card.art} position="relative">
-        {/* Corner A value (top-left) */}
-        <Text
-          position="absolute"
-          top={1}
-          left={2}
-          fontSize="14px"
-          fontWeight="bold"
-          color={card.glow}
-        >
-          {card.A}
-        </Text>
-        {/* Type badge */}
-        <Box position="absolute" top={1} right={2}>
-          <Text fontSize="8px" color={`${card.glow}bb`} letterSpacing="0.1em">
-            {card.type}
-          </Text>
-        </Box>
-        {/* Decorative crystal shape */}
-        <Box
-          position="absolute"
-          top="50%"
-          left="50%"
-          transform="translate(-50%, -50%)"
-          w="28px"
-          h="28px"
-          border={`1.5px solid ${card.glow}44`}
-          borderRadius="sm"
-          style={{ rotate: '45deg' }}
-          opacity={0.4}
-        />
-      </Box>
+    <svg width="22" height="26" viewBox="0 0 10 14" fill="none">
+      <polygon
+        points="5,0 10,4 8,13 2,13 0,4"
+        fill="rgba(6, 10, 24, 0.9)"
+        stroke={glow}
+        strokeWidth="1"
+      />
+      <polygon points="5,2 8,4.5 7,11 3,11 2,4.5" fill={glow} opacity="0.55" />
+    </svg>
+  </Box>
+)
 
-      {/* Bottom stat row: P · M · X */}
-      <Box px={2} py={1.5} borderTop={`1px solid ${card.glow}33`}>
-        <Text
-          fontSize="11px"
-          fontWeight="bold"
-          color="white"
-          mb={1}
-          lineHeight={1.3}
-          whiteSpace="pre-line"
-        >
-          {card.name}
-        </Text>
-        <Flex justify="space-between">
-          {[
-            ['P', card.P],
-            ['M', card.M],
-            ['X', card.X]
-          ].map(([k, v]) => (
-            <Flex key={k} align="baseline" gap="2px">
-              <Text fontSize="8px" color={GOLD}>
-                {k}
-              </Text>
-              <Text fontSize="11px" fontWeight="bold" color={card.glow}>
-                {v}
-              </Text>
-            </Flex>
-          ))}
-        </Flex>
+// Single achievement tile: medallion, name, tier, points, progress bar
+const AchievementTile = ({ a }) => (
+  <motion.div whileHover={{ scale: 1.04 }} transition={{ duration: 0.2 }}>
+    <Box
+      bg="rgba(6, 12, 28, 0.85)"
+      border={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.25)`}
+      borderRadius="4px"
+      p={3}
+      textAlign="center"
+      cursor="pointer"
+      _hover={{
+        borderColor: `${a.glow}88`,
+        boxShadow: `0 0 16px ${a.glow}33`
+      }}
+      transition="all 0.2s"
+    >
+      <Medallion glow={a.glow} />
+      <Text
+        mt={2}
+        fontSize="11px"
+        fontWeight="bold"
+        color="#c0e8ff"
+        lineHeight={1.3}
+        noOfLines={1}
+      >
+        {a.name}
+      </Text>
+      <Text fontSize="8px" color={`${a.glow}cc`} letterSpacing="0.12em" mb={1}>
+        {a.tier}
+      </Text>
+      {/* Gold point count (medal style) */}
+      <Text fontSize="12px" fontWeight="bold" color={KHALA_GOLD}>
+        ⬢ {a.points}
+      </Text>
+      {/* Cyan progress bar on dark track */}
+      <Box
+        mt={1.5}
+        h="5px"
+        bg="rgba(2, 6, 16, 0.9)"
+        borderRadius="2px"
+        border={`1px solid rgba(${PROTOSS_CYAN_RGB}, 0.2)`}
+      >
+        <Box
+          h="100%"
+          w={`${a.progress}%`}
+          bg={PROTOSS_CYAN}
+          borderRadius="2px"
+          boxShadow={`0 0 6px rgba(${PROTOSS_CYAN_RGB}, 0.7)`}
+        />
       </Box>
     </Box>
   </motion.div>
@@ -138,31 +126,36 @@ const TetraCard = ({ card }) => (
 
 const FfixTetraCards = () => (
   <Box
-    bg={PANEL_BG}
-    border={`2px solid ${GOLD}`}
+    bg={PROTOSS_PANEL_BG}
+    border={`2px solid rgba(${KHALA_GOLD_RGB}, 0.6)`}
     borderRadius="sm"
-    boxShadow={`0 0 0 3px rgba(8,14,40,0.9), 0 0 0 5px ${GOLD}33`}
+    boxShadow={`0 0 0 3px rgba(10,8,24,0.9), 0 0 0 5px rgba(${KHALA_GOLD_RGB}, 0.2)`}
     overflow="hidden"
     fontFamily="monospace"
   >
-    <Box
+    <Flex
       px={3}
       py={2}
-      bg="rgba(0,187,221,0.06)"
-      borderBottom={`1px solid ${GOLD}44`}
+      bg={`rgba(${KHALA_GOLD_RGB}, 0.07)`}
+      borderBottom={`1px solid rgba(${KHALA_GOLD_RGB}, 0.35)`}
+      justify="space-between"
+      align="center"
     >
-      <Text fontSize="10px" color={GOLD} letterSpacing="0.15em">
-        ◆ TETRA MASTER — PROJECT CARDS
+      <Text fontSize="10px" color={PROTOSS_CYAN} letterSpacing="0.15em">
+        ▸ ACHIEVEMENTS — SERVICE RECORD
       </Text>
-    </Box>
+      <Text fontSize="10px" color={KHALA_GOLD}>
+        ⬢ {ACHIEVEMENTS.reduce((s, a) => s + a.points, 0)}
+      </Text>
+    </Flex>
     <SimpleGrid columns={{ base: 2, sm: 4 }} gap={3} p={3}>
-      {CARDS.map(card => (
-        <TetraCard key={card.name} card={card} />
+      {ACHIEVEMENTS.map(a => (
+        <AchievementTile key={a.name} a={a} />
       ))}
     </SimpleGrid>
     <Box px={3} pb={2}>
-      <Text fontSize="9px" color="#9890a0" letterSpacing="0.08em">
-        A=Attack · P=Physical · M=Magic · X=Flexible
+      <Text fontSize="9px" color={MUTED} letterSpacing="0.08em">
+        CAMPAIGN PROGRESS ACROSS ACTIVE OPERATIONS
       </Text>
     </Box>
   </Box>

--- a/components/layouts/main.js
+++ b/components/layouts/main.js
@@ -123,7 +123,7 @@ const Main = ({ children, router }) => {
 
       <NavBar path={router.asPath} />
 
-      <Container maxW="container.xl" pt={14}>
+      <Container maxW="container.xl" pt={16}>
         {theme === 'sc2' ? <LazyProtossPylon /> : <LazySword />}
 
         {children}

--- a/components/layouts/main.js
+++ b/components/layouts/main.js
@@ -3,6 +3,7 @@ import dynamic from 'next/dynamic'
 import NavBar from '../navbar'
 import ProtossGlobal from '../sc2/protoss-global'
 import ProtossShieldLayer from '../protoss-shield-layer'
+import PlanetHorizon from '../planet-horizon'
 import { Box, Container } from '@chakra-ui/react'
 import Footer from '../footer'
 import VoxelDogLoader from '../voxel-dog-loader'
@@ -116,6 +117,7 @@ const Main = ({ children, router }) => {
       </Head>
 
       {theme === 'sc2' && <ProtossGlobal />}
+      {theme === 'sc2' && <PlanetHorizon />}
       {theme === 'sc2' && <LazyPsionicBackground />}
       {theme === 'sc2' && <ProtossShieldLayer />}
 

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -23,8 +23,9 @@ import {
 // GameThemeToggle + ThemeToggleButton removed while FFIX is hidden (#7) —
 // site is locked to the SC2 dark console look. Components kept for re-enable.
 
-// LotV capsule menu button (#16): rounded capsule, thin blue border,
-// dark gradient fill; active = double-border glow (ref: LotV achievements UI)
+// LotV challenges-style top menu tab (#19): large uppercase text item;
+// active = raised gradient block with a bright top edge (ref: LotV
+// challenges screen — CAMPAGNE tab)
 const LinkItem = ({ href, path, target, children, ...props }) => {
   const active = path === href
   return (
@@ -32,34 +33,29 @@ const LinkItem = ({ href, path, target, children, ...props }) => {
       as={NextLink}
       href={href}
       scroll={false}
-      px={4}
-      py={1.5}
+      px={5}
+      py={2.5}
       fontFamily="mono"
-      fontSize="xs"
+      fontSize="sm"
       fontWeight="bold"
       textTransform="uppercase"
-      letterSpacing="0.12em"
-      borderRadius="6px"
-      border="1px solid"
-      borderColor={
+      letterSpacing="0.16em"
+      bg={
         active
-          ? `rgba(${PROTOSS_CYAN_RGB}, 0.9)`
-          : `rgba(${PROTOSS_CYAN_RGB}, 0.3)`
+          ? 'linear-gradient(180deg, rgba(34, 64, 118, 0.95), rgba(10, 20, 45, 0.95))'
+          : 'transparent'
       }
-      bg="linear-gradient(180deg, rgba(14, 24, 48, 0.9), rgba(5, 10, 24, 0.9))"
-      color={active ? '#eafcff' : '#8fb8cc'}
+      color={active ? '#ffffff' : '#8fb8cc'}
       boxShadow={
         active
-          ? `inset 0 0 0 1px rgba(${PROTOSS_CYAN_RGB}, 0.55), 0 0 12px rgba(${PROTOSS_CYAN_RGB}, 0.35)`
+          ? `inset 0 2px 0 rgba(${PROTOSS_CYAN_RGB}, 0.9), inset 0 0 24px rgba(${PROTOSS_CYAN_RGB}, 0.18), 0 0 14px rgba(${PROTOSS_CYAN_RGB}, 0.25)`
           : 'none'
       }
-      textShadow={active ? `0 0 10px rgba(${PROTOSS_CYAN_RGB}, 0.7)` : 'none'}
+      textShadow={active ? `0 0 12px rgba(${PROTOSS_CYAN_RGB}, 0.8)` : 'none'}
       _hover={{
         textDecoration: 'none',
-        color: '#c0e8ff',
-        borderColor: `rgba(${PROTOSS_CYAN_RGB}, 0.7)`,
-        boxShadow: `0 0 10px rgba(${PROTOSS_CYAN_RGB}, 0.25)`,
-        textShadow: `0 0 8px rgba(${PROTOSS_CYAN_RGB}, 0.6)`
+        color: '#eafcff',
+        textShadow: `0 0 10px rgba(${PROTOSS_CYAN_RGB}, 0.6)`
       }}
       _focusVisible={{
         color: '#c0e8ff',

--- a/components/planet-horizon.js
+++ b/components/planet-horizon.js
@@ -1,0 +1,55 @@
+import { Box } from '@chakra-ui/react'
+import { PROTOSS_CYAN_RGB, PROTOSS_TEAL_RGB } from '../lib/site-theme-context'
+
+// Mission-briefing space backdrop (#19): planet seen from orbit with a
+// cyan atmosphere rim (ref: LotV challenges screen). Pure static CSS —
+// no animation cost, no reduced-motion concerns. Sits at the very back
+// of the fixed layer stack (planet −3, psionic canvas −2, shield −1).
+const PlanetHorizon = () => (
+  <Box
+    aria-hidden
+    position="fixed"
+    inset={0}
+    zIndex={-3}
+    pointerEvents="none"
+    overflow="hidden"
+  >
+    {/* Deep-space nebula tint, upper left */}
+    <Box
+      position="absolute"
+      top="-20%"
+      left="-10%"
+      w="70vmax"
+      h="70vmax"
+      borderRadius="full"
+      background="radial-gradient(circle, rgba(40, 20, 80, 0.25), transparent 65%)"
+    />
+
+    {/* Planet body — huge circle rising from the bottom-right, only the
+        upper arc is visible in the viewport */}
+    <Box
+      position="absolute"
+      bottom="-130vmax"
+      right="-60vmax"
+      w="160vmax"
+      h="160vmax"
+      borderRadius="full"
+      background={`radial-gradient(circle at 30% 25%, #0c1c30 0%, #071220 40%, #030810 75%)`}
+      boxShadow={`0 0 90px 24px rgba(${PROTOSS_CYAN_RGB}, 0.22), inset 40px 60px 160px rgba(${PROTOSS_TEAL_RGB}, 0.18)`}
+    />
+
+    {/* Atmosphere rim highlight along the horizon arc */}
+    <Box
+      position="absolute"
+      bottom="-130.4vmax"
+      right="-60.4vmax"
+      w="160.8vmax"
+      h="160.8vmax"
+      borderRadius="full"
+      border={`1.5px solid rgba(${PROTOSS_CYAN_RGB}, 0.45)`}
+      filter="blur(1px)"
+    />
+  </Box>
+)
+
+export default PlanetHorizon

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,7 +21,7 @@ import { FfixTechMenu, FfixInterestTags } from '../components/ffix-battle-menu'
 import FfixEquipment from '../components/ffix-equipment'
 import FfixStatusEffects from '../components/ffix-status-effects'
 import FfixMognet from '../components/ffix-mognet'
-import FfixTetraCards from '../components/ffix-tetra-card'
+import AchievementsPanel from '../components/achievements-panel'
 import FfixEncounter from '../components/ffix-encounter'
 import FfixWorldMap from '../components/ffix-world-map'
 import ProtossWarpIn from '../components/protoss-warp-in'
@@ -340,7 +340,7 @@ const Home = () => {
               <Heading as="h3" variant="section-title">
                 {PROTOSS_LABELS.featured}
               </Heading>
-              <FfixTetraCards />
+              <AchievementsPanel />
             </Section>
 
             {/* CAREER — mobile only (shows inline in stack) */}


### PR DESCRIPTION
Closes #19 — mothership/mission-briefing direction from owner + two LotV references.

## Changes
- **Planet-horizon backdrop** (new `planet-horizon.js`): planet seen from orbit — dark body, cyan atmosphere rim, nebula tint; pure static CSS, layer stack planet −3 / psionic canvas −2 / shield −1 (ref: LotV challenges screen)
- **Achievements panel** (`ffix-tetra-card.js` → `achievements-panel.js`): featured projects as LotV achievement tiles — icon medallions with per-project glow, tier labels, gold ⬢ point counts, cyan progress bars, header total (ref: LotV achievements summary)
- **LotV tab menu** (`navbar.js`): large uppercase text tabs; active = raised gradient block with bright top edge + glow (replaces the #16 capsules per owner direction)

## Verification
- yarn lint 0 errors, yarn build ✓, no new deps, tokens only
- Independent review: COMMENT, 0 blockers — all findings fixed (content offset for taller navbar, component rename, cursor affordance, decorative SVG a11y, tier label legibility)
- Focus-visible preserved on tabs; backdrop static (no reduced-motion cost)